### PR TITLE
Capture Mock

### DIFF
--- a/capture/package.json
+++ b/capture/package.json
@@ -19,11 +19,13 @@
     "@types/node": "8.0.53",
     "aws-sdk": "^2.188.0",
     "child_process": "^1.0.2",
+    "command-line-args": "^5.0.1",
     "mysql": "^2.15.0",
     "path": "^0.12.7"
   },
   "devDependencies": {
     "@types/chai": "^4.0.5",
+    "@types/command-line-args": "^4.0.2",
     "@types/mocha": "^2.2.44",
     "@types/mysql": "^2.15.2",
     "chai": "^4.1.2",

--- a/capture/package.json
+++ b/capture/package.json
@@ -29,6 +29,7 @@
     "@types/mocha": "^2.2.44",
     "@types/mysql": "^2.15.2",
     "chai": "^4.1.2",
+    "command-line-usage": "^4.1.0",
     "mocha": "^4.0.1",
     "tslint": "^5.8.0",
     "typescript": "^2.6.1"

--- a/capture/scripts/usage.js
+++ b/capture/scripts/usage.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const getUsage = require('command-line-usage');
+const options = require('../dist/args').captureOptions;
+console.log(getUsage([
+   {
+      header: 'MyCRT Capture Process',
+      content: 'Runs a capture on a target database',
+   },
+   {
+      header: 'Usage',
+      content: 'mycrt-capture --id [underline]{number} [Options...]',
+   },
+   {
+      header: 'Options',
+      optionList: options,
+   },
+]));

--- a/capture/src/args.ts
+++ b/capture/src/args.ts
@@ -10,7 +10,7 @@ import { OptionDefinition } from 'command-line-args';
 const optionId: OptionDefinition = {
    name: 'id',
    type: Number,
-   description: "The id of this capture. This is used to communicate with the MyCRT DB and S3",
+   description: "The id of this capture, used to communicate with the MyCRT DB and S3 [bold]{REQUIRED}",
 };
 
 const optionMock: OptionDefinition = {

--- a/capture/src/args.ts
+++ b/capture/src/args.ts
@@ -7,13 +7,13 @@ import { OptionDefinition } from 'command-line-args';
 // notation rules documented here
 // https://github.com/75lb/command-line-args/wiki/Notation-rules
 
-const optionId: OptionDefinition = {
+export const optionId: OptionDefinition = {
    name: 'id',
    type: Number,
    description: "The id of this capture, used to communicate with the MyCRT DB and S3 [bold]{REQUIRED}",
 };
 
-const optionMock: OptionDefinition = {
+export const optionMock: OptionDefinition = {
    name: 'mock',
    alias: 'm',
    type: Boolean,
@@ -21,7 +21,7 @@ const optionMock: OptionDefinition = {
    description: "Whether or not the capture should be performed as a mock",
 };
 
-const optionInterval: OptionDefinition = {
+export const optionInterval: OptionDefinition = {
    name: 'interval',
    alias: 'i',
    type: Number,
@@ -29,7 +29,7 @@ const optionInterval: OptionDefinition = {
    description: "Frequency of the processing interval in ms.",
 };
 
-const optionIntervalOverlap: OptionDefinition = {
+export const optionIntervalOverlap: OptionDefinition = {
    name: 'intervalOverlap',
    alias: 'o',
    type: Number,
@@ -37,7 +37,7 @@ const optionIntervalOverlap: OptionDefinition = {
    description: "The amount of overlap time between metric retrievals.",
 };
 
-const optionSupervised: OptionDefinition = {
+export const optionSupervised: OptionDefinition = {
    name: 'supervised',
    alias: 's',
    type: Boolean,
@@ -100,11 +100,6 @@ export class CaptureConfig {
 
    private makeOptionArgs(option: OptionDefinition, value: any): string[] {
 
-      const valueStr: string = value.toString();
-      if (valueStr.length <= 0) {
-         return [];
-      }
-
       let key: string;
       if (option.name) {
          key = `--${option.name}`;
@@ -114,7 +109,14 @@ export class CaptureConfig {
          throw new Error("Cannot make option arguments without a name or alias");
       }
 
-      return [key, valueStr];
+      if (option.type !== Boolean) {
+         return [key, value.toString()];
+      } else if (value) {
+         return [key];
+      } else {
+         return [];
+      }
+
    }
 
 }

--- a/capture/src/args.ts
+++ b/capture/src/args.ts
@@ -1,0 +1,120 @@
+import * as readCmdArgs from 'command-line-args';
+import { OptionDefinition } from 'command-line-args';
+
+// command-line-args documentation here
+// https://github.com/75lb/command-line-args
+//
+// notation rules documented here
+// https://github.com/75lb/command-line-args/wiki/Notation-rules
+
+const optionId: OptionDefinition = {
+   name: 'id',
+   type: Number,
+   description: "The id of this capture. This is used to communicate with the MyCRT DB and S3",
+};
+
+const optionMock: OptionDefinition = {
+   name: 'mock',
+   alias: 'm',
+   type: Boolean,
+   defaultValue: false,
+   description: "Whether or not the capture should be performed as a mock",
+};
+
+const optionInterval: OptionDefinition = {
+   name: 'interval',
+   alias: 'i',
+   type: Number,
+   defaultValue: 5 * 60 * 1000,
+   description: "Frequency of the processing interval in ms.",
+};
+
+const optionIntervalOverlap: OptionDefinition = {
+   name: 'intervalOverlap',
+   alias: 'o',
+   type: Number,
+   defaultValue: 1 * 60 * 1000,
+   description: "The amount of overlap time between metric retrievals.",
+};
+
+const optionSupervised: OptionDefinition = {
+   name: 'supervised',
+   alias: 's',
+   type: Boolean,
+   defaultValue: true,
+   description: "Whether or not this capture is supervised by the MyCRT service",
+};
+
+export const captureOptions: OptionDefinition[] = [optionId, optionMock, optionInterval,
+   optionIntervalOverlap, optionSupervised];
+
+export class CaptureConfig {
+
+   public static fromCmdArgs(): CaptureConfig {
+
+      const options = readCmdArgs(captureOptions);
+      if (!options.id) {
+         throw new Error("No id was provided for the capture");
+      }
+
+      const config = new CaptureConfig(options.id);
+      config.mock = options.mock;
+      config.interval = options.interval;
+      config.intervalOverlap = options.intervalOverlap;
+      config.supervised = options.supervised;
+
+      return config;
+   }
+
+   public id: number;
+   public mock: boolean = optionMock.defaultValue;
+   public interval: number = optionInterval.defaultValue;
+   public intervalOverlap: number = optionIntervalOverlap.defaultValue;
+   public supervised: boolean = optionSupervised.defaultValue;
+
+   constructor(id: number) {
+      this.id = id;
+   }
+
+   public toArgList(): string[] {
+
+      const options = [
+         [optionId, this.id],
+         [optionMock, this.mock],
+         [optionInterval, this.interval],
+         [optionIntervalOverlap, this.intervalOverlap],
+         [optionSupervised, this.supervised],
+      ];
+
+      let result: string[] = [];
+      for (const pair of options) {
+         result = result.concat(this.makeOptionArgs.apply(this, pair));
+      }
+
+      return result;
+   }
+
+   public toString(): string {
+      return this.toArgList().join(' ');
+   }
+
+   private makeOptionArgs(option: OptionDefinition, value: any): string[] {
+
+      const valueStr: string = value.toString();
+      if (valueStr.length <= 0) {
+         return [];
+      }
+
+      let key: string;
+      if (option.name) {
+         key = `--${option.name}`;
+      } else if (option.alias) {
+         key = `-${option.alias}`;
+      } else {
+         throw new Error("Cannot make option arguments without a name or alias");
+      }
+
+      return [key, valueStr];
+   }
+
+}

--- a/capture/src/capture.ts
+++ b/capture/src/capture.ts
@@ -84,7 +84,9 @@ export class Capture implements ICaptureIpcNodeDelegate {
    }
 
    private done: boolean = false;
+   private loopTimeoutId: NodeJS.Timer | null = null;
    private readonly startTime: Date = new Date();
+
    private ipcNode: CaptureIpcNode;
    private metricConfig: MetricConfiguration;
    private storage: StorageBackend;
@@ -116,7 +118,7 @@ export class Capture implements ICaptureIpcNodeDelegate {
          throw new Error("unsupervised capture mode has not been implemented yet!");
       }
       logger.info(`Capture ${this.id} is looping!`);
-      setTimeout(() => {
+      this.loopTimeoutId = setInterval(() => {
          this.loop();
       }, this.config.interval);
    }
@@ -124,7 +126,7 @@ export class Capture implements ICaptureIpcNodeDelegate {
    public async onStop(): Promise<any> {
       logger.info(`Capture ${this.id} received stop signal!`);
       this.done = true;
-      return;
+      this.loop();
    }
 
    private async setup(): Promise<void> {
@@ -151,9 +153,8 @@ export class Capture implements ICaptureIpcNodeDelegate {
       logger.info(`Capture ${this.id}: loop start`);
 
       if (this.done) {
+         clearInterval(this.loopTimeoutId!);
          this.teardown();
-      } else {
-         setTimeout(() => { this.loop(); }, this.config.interval);
       }
    }
 

--- a/capture/src/capture.ts
+++ b/capture/src/capture.ts
@@ -124,21 +124,7 @@ export class Capture implements ICaptureIpcNodeDelegate {
    public async onStop(): Promise<any> {
       logger.info(`Capture ${this.id} received stop signal!`);
       this.done = true;
-
-      logger.info("set status to dead");
-      await Capture.updateCaptureStatus(this.id, "dead").catch((reason) => {
-         logger.error(`Failed to set status to dead: ${reason}`);
-      });
-      logger.info("record end time");
-      await Capture.updateCaptureEndTime(this.id).catch((reason) => {
-         logger.error(`Failed to record end time: ${reason}`);
-      });
-      logger.info("save workload");
-      const s3res = await stopRdsLoggingAndUploadToS3().catch((reason) => {
-         logger.error(`Failed to upload RDS log to S3: ${reason}`);
-      });
-      logger.info(`Got S3 location!: ${s3res}`);
-      return s3res;
+      return;
    }
 
    private async setup(): Promise<void> {
@@ -224,6 +210,22 @@ export class Capture implements ICaptureIpcNodeDelegate {
 
    private async teardown() {
       logger.info(`Performing teardown for Capture ${this.id}`);
+
+      logger.info("set status to dead");
+      await Capture.updateCaptureStatus(this.id, "dead").catch((reason) => {
+         logger.error(`Failed to set status to dead: ${reason}`);
+      });
+
+      logger.info("record end time");
+      await Capture.updateCaptureEndTime(this.id).catch((reason) => {
+         logger.error(`Failed to record end time: ${reason}`);
+      });
+
+      logger.info("save workload");
+      const s3res = await stopRdsLoggingAndUploadToS3().catch((reason) => {
+         logger.error(`Failed to upload RDS log to S3: ${reason}`);
+      });
+      logger.info(`Got S3 location!: ${s3res}`);
 
       await this.sendMetricsToS3(this.storage, this.startTime, new Date());
 

--- a/capture/src/launch.ts
+++ b/capture/src/launch.ts
@@ -17,7 +17,7 @@ export const launch = (config: CaptureConfig) => {
    child_process.spawn(childName, args)
 
       .stdout.on('data', (data: string) => {
-         logger.info("[capture stdout]  " + data);
+         logger.info("[capture stdout]  " + data.toString().trim());
       })
 
       .on('close', (code: any) => {
@@ -25,7 +25,7 @@ export const launch = (config: CaptureConfig) => {
       })
 
       .on('error', (error: string) => {
-         logger.error(`Capture ${config.id} errorred: ${error}`);
+         logger.error(`Capture ${config.id} errorred: ${error.toString().trim()}`);
       })
 
    ;

--- a/capture/src/launch.ts
+++ b/capture/src/launch.ts
@@ -2,15 +2,19 @@ import * as child_process from 'child_process';
 
 import { Logging } from '@lbt-mycrt/common';
 
-import { ICaptureConfig } from './capture';
+import { CaptureConfig } from './args';
 
 const logger = Logging.getLogger(true, Logging.simpleFormatter);
 
-export const launch = (config: ICaptureConfig) => {
+export const launch = (config: CaptureConfig) => {
 
    logger.info("launching capture");
 
-   child_process.spawn('mycrt-capture', [`${config.id}`])
+   const childName = 'mycrt-capture';
+   const args = config.toArgList();
+   logger.info(`   ${childName} ${args.join(' ')}`);
+
+   child_process.spawn(childName, args)
 
       .stdout.on('data', (data: string) => {
          logger.info("[capture stdout]  " + data);

--- a/capture/src/main.ts
+++ b/capture/src/main.ts
@@ -18,3 +18,4 @@ if (typeof(require) !== 'undefined' && require.main === module) {
 }
 
 export { launch } from './launch';
+export { CaptureConfig } from './args';

--- a/capture/src/main.ts
+++ b/capture/src/main.ts
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 
+import { S3 } from 'aws-sdk';
+
 import { Logging } from '@lbt-mycrt/common';
+import { StorageBackend } from '@lbt-mycrt/common/dist/storage/backend';
+import { LocalBackend } from '@lbt-mycrt/common/dist/storage/local-backend';
+import { S3Backend } from '@lbt-mycrt/common/dist/storage/s3-backend';
+import { getSandboxPath } from '@lbt-mycrt/common/dist/storage/sandbox';
 
 import { CaptureConfig } from './args';
 import { Capture } from './capture';
@@ -10,7 +16,12 @@ if (typeof(require) !== 'undefined' && require.main === module) {
    const logger = Logging.getLogger(true, Logging.simpleFormatter);
 
    logger.info("Configuring MyCRT Capture Program");
-   const capture = new Capture(CaptureConfig.fromCmdArgs());
+   const config = CaptureConfig.fromCmdArgs();
+   logger.info(config.toString());
+
+   const storage: StorageBackend = config.mock ? new LocalBackend(getSandboxPath())
+      : new S3Backend(new S3(), "lil-test-environment"); // TODO: get bucket name from the environment
+   const capture = new Capture(config, storage);
 
    logger.info("Running MyCRT Capture Program");
    capture.run();

--- a/capture/src/main.ts
+++ b/capture/src/main.ts
@@ -2,6 +2,7 @@
 
 import { Logging } from '@lbt-mycrt/common';
 
+import { CaptureConfig } from './args';
 import { Capture } from './capture';
 
 if (typeof(require) !== 'undefined' && require.main === module) {
@@ -9,13 +10,7 @@ if (typeof(require) !== 'undefined' && require.main === module) {
    const logger = Logging.getLogger(true, Logging.simpleFormatter);
 
    logger.info("Configuring MyCRT Capture Program");
-   const config = {
-      id: +process.argv[2],
-      interval: 2000, // 2 seconds
-      supervised: true,
-   };
-
-   const capture = new Capture(config);
+   const capture = new Capture(CaptureConfig.fromCmdArgs());
 
    logger.info("Running MyCRT Capture Program");
    capture.run();

--- a/capture/src/test/args.test.ts
+++ b/capture/src/test/args.test.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import * as args from '../args';
+
+describe("CaptureConfig", () => {
+
+   it("should make the correct option arguments", () => {
+      const config = new args.CaptureConfig(8);
+      const expected = [
+         `--${args.optionId.name}`, '8',
+         `--${args.optionInterval.name}`, `${args.optionInterval.defaultValue}`,
+         `--${args.optionIntervalOverlap.name}`, `${args.optionIntervalOverlap.defaultValue}`,
+         `--${args.optionSupervised.name}`,
+      ];
+      const actual = config.toArgList();
+      expect(expected.length).to.equal(actual.length);
+      expected.forEach((val, index) => {
+         expect(val).to.equal(actual[index]);
+      });
+   });
+
+});

--- a/capture/src/test/launch.test.ts
+++ b/capture/src/test/launch.test.ts
@@ -1,9 +1,10 @@
 import 'mocha';
 
+import { CaptureConfig } from '../args';
 import { launch } from '../launch';
 
 describe("launch", () => {
    it("should not fail", () => {
-      launch({ id: 123 });
+      launch(new CaptureConfig(123));
    });
 });

--- a/cli/src/mycrt-client/client.ts
+++ b/cli/src/mycrt-client/client.ts
@@ -25,8 +25,8 @@ export class MyCrtClient {
    }
 
    /** Create a new Capture */
-   public async startCapture(capture: IChildProgram): Promise<number | null> {
-      return this.makeRequest<number>(HttpMethod.POST, '/captures', null, capture);
+   public async startCapture(capture: IChildProgram): Promise<IChildProgram | null> {
+      return this.makeRequest<IChildProgram>(HttpMethod.POST, '/captures', null, capture);
    }
 
    /** Stop a specific capture */

--- a/cli/src/mycrt-client/client.ts
+++ b/cli/src/mycrt-client/client.ts
@@ -10,6 +10,7 @@ export enum HttpMethod { GET = 'GET', POST = 'POST', PUT = 'PUT', DELETE = 'DELE
 export class MyCrtClient {
 
    private readonly host: string;
+
    /**
     * Using a delegate allows the client to work in both the Node runtime (cli) and in browsers (gui).
     * This is because the Node runtime should use the file system (not available in the browser),
@@ -30,7 +31,7 @@ export class MyCrtClient {
 
    /** Stop a specific capture */
    public async stopCapture(id: number): Promise<any> {
-      return this.makeRequest<IChildProgram>(HttpMethod.POST, `/captures/${id}/stop`);
+      return this.makeRequest<any>(HttpMethod.POST, `/captures/${id}/stop`);
    }
 
    /** Retrieve all of the captures */

--- a/common/src/storage/sandbox.ts
+++ b/common/src/storage/sandbox.ts
@@ -1,0 +1,11 @@
+import fs = require('fs-extra');
+import path = require('path');
+
+const SANDBOX_PATH = '/tmp/MyCRT/sandbox/';
+
+export const getSandboxPath = (): string => {
+   if (!fs.pathExistsSync(SANDBOX_PATH)) {
+      fs.mkdirsSync(SANDBOX_PATH);
+   }
+   return SANDBOX_PATH;
+};

--- a/gui/src/mustache.ts
+++ b/gui/src/mustache.ts
@@ -19,7 +19,7 @@ export class Template {
    private readonly mustacheFile: string;
    private partials: Template[];
 
-   private mustacheFileText: string;
+   private mustacheFileText: string = "";
 
    private parsed: boolean;
    private topLevel: boolean;

--- a/replay/src/launch.ts
+++ b/replay/src/launch.ts
@@ -13,7 +13,7 @@ export const launch = (config: IReplayConfig) => {
    child_process.spawn('mycrt-replay', [`${config.id}`])
 
       .stdout.on('data', (data: string) => {
-         logger.info("[replay stdout] " + data);
+         logger.info("[replay stdout] " + data.toString().trim());
       })
 
       .on('close', (code: any) => {
@@ -21,7 +21,7 @@ export const launch = (config: IReplayConfig) => {
       })
 
       .on('error', (error: string) => {
-         logger.error(`Replay ${config.id} errorred: ${error}`);
+         logger.error(`Replay ${config.id} errorred: ${error.toString().trim()}`);
       })
 
    ;

--- a/scripts/tslint.json
+++ b/scripts/tslint.json
@@ -11,7 +11,8 @@
        "no-unused-expression": false,
        "object-literal-sort-keys": false,
        "max-classes-per-file": [ true, 3, "exclude-class-expressions" ],
-       "radix": false
+       "radix": false,
+       "forin": false
     },
     "rulesDirectory": [],
     "typedef": [

--- a/service/mycrt.config.json
+++ b/service/mycrt.config.json
@@ -1,3 +1,5 @@
 {
-   "name": "MyCRT Server"
+   "name": "MyCRT Server",
+   "mockCaptures": true,
+   "mockReplays": true
 }

--- a/service/mycrt.config.json
+++ b/service/mycrt.config.json
@@ -1,9 +1,11 @@
 {
    "name": "MyCRT Server",
    "captures": {
-      "mock": true
+      "mock": true,
+      "interval": 2000
    },
    "replays": {
-      "mock": true
+      "mock": true,
+      "interval": 2000
    }
 }

--- a/service/mycrt.config.json
+++ b/service/mycrt.config.json
@@ -1,5 +1,9 @@
 {
    "name": "MyCRT Server",
-   "mockCaptures": true,
-   "mockReplays": true
+   "captures": {
+      "mock": true
+   },
+   "replays": {
+      "mock": true
+   }
 }

--- a/service/src/main.ts
+++ b/service/src/main.ts
@@ -12,12 +12,9 @@ import { Pages, StaticFileDirs, Template } from '@lbt-mycrt/gui';
 
 import ApiRouter from './routes/api';
 import SelfAwareRouter from './routes/self-aware-router';
+import settings = require('./settings');
 
 const logger = Logging.defaultLogger(__dirname);
-
-/* tslint:disable no-var-requires */
-const config = require('../mycrt.config.json');
-/* tslint:enable no-var-requires */
 
 class MyCrtService {
 
@@ -40,6 +37,13 @@ class MyCrtService {
       return this.port !== null;
    }
 
+   public setting(key: string): any {
+      if (this.express === null) {
+         return undefined;
+      }
+      return this.express.get(key);
+   }
+
    public launch(): Promise<boolean> {
 
       return new Promise<boolean>(async (resolve, reject) => {
@@ -58,8 +62,8 @@ class MyCrtService {
          this.host = process.env.host ? process.env.host as string : this.DEFAULT_HOST;
 
          // configure the application
-         for (const key of config) {
-            this.express.set(key, config[key]);
+         for (const key in settings) {
+            this.express.set(key, (settings as any)[key]);
          }
 
          // start the IpcNode

--- a/service/src/routes/capture.ts
+++ b/service/src/routes/capture.ts
@@ -87,6 +87,7 @@ export default class CaptureRouter extends SelfAwareRouter {
 
                const config = new CaptureConfig(result.insertId);
                config.mock = settings.captures.mock;
+               config.interval = settings.captures.interval;
 
                launch(config);
 

--- a/service/src/routes/capture.ts
+++ b/service/src/routes/capture.ts
@@ -2,7 +2,7 @@ import { S3 } from 'aws-sdk';
 import * as http from 'http-status-codes';
 import * as mysql from 'mysql';
 
-import { launch } from '@lbt-mycrt/capture';
+import { CaptureConfig, launch } from '@lbt-mycrt/capture';
 import { ChildProgramStatus, ChildProgramType, IMetric,
          IMetricsList, Logging, MetricsBackend, MetricType } from '@lbt-mycrt/common';
 import { S3Backend } from '@lbt-mycrt/common/dist/storage/s3-backend';
@@ -82,7 +82,7 @@ export default class CaptureRouter extends SelfAwareRouter {
             /* Add validation for insert */
             ConnectionPool.query(response, insertStr, (error, result) => {
                logger.info(`Launching capture with id ${result.insertId}`);
-               launch({ id: result.insertId });
+               launch(new CaptureConfig(result.insertId));
 
                logger.info(`Successfully created capture!`);
                response.json(result.insertId);

--- a/service/src/routes/capture.ts
+++ b/service/src/routes/capture.ts
@@ -67,11 +67,11 @@ export default class CaptureRouter extends SelfAwareRouter {
          .post('/:id/stop', async (request, response) => {
 
             const captureId = request.params.id;
-            const s3res: any = await this.ipcNode.stopCapture(captureId).catch((reason) => {
+            await this.ipcNode.stopCapture(captureId).catch((reason) => {
                logger.error(`Failed to stop capture ${captureId}: ${reason}`);
             });
-            logger.info(`Capture ${captureId} stopped! workload file at ${s3res}`);
-            response.json(s3res).end();
+            logger.info(`Capture ${captureId} stopped!`);
+            response.status(http.OK).end();
 
          })
 

--- a/service/src/routes/capture.ts
+++ b/service/src/routes/capture.ts
@@ -7,6 +7,7 @@ import { ChildProgramStatus, ChildProgramType, IMetric,
          IMetricsList, Logging, MetricsBackend, MetricType } from '@lbt-mycrt/common';
 import { S3Backend } from '@lbt-mycrt/common/dist/storage/s3-backend';
 
+import { settings } from '../settings';
 import SelfAwareRouter from './self-aware-router';
 import ConnectionPool from './util/cnnPool';
 
@@ -18,6 +19,7 @@ export default class CaptureRouter extends SelfAwareRouter {
       const logger = Logging.defaultLogger(__dirname);
 
       this.router
+
          .get('/', (request, response) => {
             const queryStr = mysql.format("SELECT * FROM Capture", []);
             ConnectionPool.query(response, queryStr, (error, rows, fields) => {
@@ -82,7 +84,11 @@ export default class CaptureRouter extends SelfAwareRouter {
             /* Add validation for insert */
             ConnectionPool.query(response, insertStr, (error, result) => {
                logger.info(`Launching capture with id ${result.insertId}`);
-               launch(new CaptureConfig(result.insertId));
+
+               const config = new CaptureConfig(result.insertId);
+               config.mock = settings.captures.mock;
+
+               launch(config);
 
                logger.info(`Successfully created capture!`);
                response.json(result.insertId);

--- a/service/src/routes/capture.ts
+++ b/service/src/routes/capture.ts
@@ -92,7 +92,7 @@ export default class CaptureRouter extends SelfAwareRouter {
                launch(config);
 
                logger.info(`Successfully created capture!`);
-               response.json(result.insertId);
+               response.json({id: result.insertId}).end(); // TODO: query for the capture, and return the whole object
 
             });
          })

--- a/service/src/settings.ts
+++ b/service/src/settings.ts
@@ -1,0 +1,3 @@
+
+// tslint:disable-next-line:no-var-requires
+export const settings: any = require('../mycrt.config.json');


### PR DESCRIPTION
captures can be launched in a "mock" mode. This is enabled/disabled by changing the "captures.mock" setting in `service/mycrt.config.json`. Right now, it is on by default.

https://github.com/CPSECapstone/LilBobbyTables-MyCRT/wiki/MyCRT-Config

I also formalized the parameters for configuring a capture, and cleaned up the capture process code so that the stop request is much quicker.