### PR TITLE
Http Error Handling

### DIFF
--- a/common/src/dao/capture-dao.ts
+++ b/common/src/dao/capture-dao.ts
@@ -27,8 +27,8 @@ export class CaptureDao extends Dao {
    }
 
    public deleteCapture(id: number): Promise<data.ICapture> {
-       // tslint:disable-next-line:max-line-length
-       return this.query<any>('DELETE c.*, r.* from Capture c LEFT JOIN Replay r on r.captureId = c.id where c.id = ?', [id]);
+      return this.query<any>('DELETE c.*, r.* from Capture c LEFT JOIN Replay r on r.captureId = c.id where c.id = ?',
+         [id]);
    }
 
    public updateCaptureStatus(id: number, status: data.ChildProgramStatus): Promise<void> {

--- a/common/src/dao/capture-dao.ts
+++ b/common/src/dao/capture-dao.ts
@@ -7,15 +7,18 @@ export class CaptureDao extends Dao {
    // TODO: should we paginate this?
    public async getAllCaptures(): Promise<data.ICapture[]> {
       const rawCaptures = await this.query<any[]>('SELECT * FROM Capture', []);
-      return rawCaptures.map(this.resultToICapture);
+      return rawCaptures.map(this.rowToICapture);
    }
 
-   public async getCapture(id: number): Promise<data.ICapture> {
-      const result = await this.query<data.ICapture[]>('SELECT * FROM Capture WHERE id = ?', [id]);
-      return this.resultToICapture(result[0]);
+   public async getCapture(id: number): Promise<data.ICapture | null> {
+      const result = await this.query<any[]>('SELECT * FROM Capture WHERE id = ?', [id]);
+      if (result.length === 0) {
+         return null;
+      }
+      return this.rowToICapture(result[0]);
    }
 
-   public async makeCapture(capture: data.ICapture): Promise<data.ICapture> {
+   public async makeCapture(capture: data.ICapture): Promise<data.ICapture | null> {
       const result = await this.query<any>('INSERT INTO Capture SET ?', {
          name: capture.name,
          status: capture.status,
@@ -35,7 +38,7 @@ export class CaptureDao extends Dao {
       return this.query('UPDATE Capture SET end = NOW() WHERE id = ?', [id]);
    }
 
-   private resultToICapture(captureData: any): data.ICapture {
+   private rowToICapture(captureData: any): data.ICapture {
       return {
          id: captureData.id,
          name: captureData.name,

--- a/common/src/dao/environment-dao.ts
+++ b/common/src/dao/environment-dao.ts
@@ -9,12 +9,15 @@ export class EnvironmentDao extends Dao {
       return environmentRows.map(this.rowToIEnvironment);
    }
 
-   public async getEnvironment(id: number): Promise<data.IEnvironment> {
+   public async getEnvironment(id: number): Promise<data.IEnvironment | null> {
       const rows = await this.query<any[]>('SELECT * FROM Environment WHERE id = ?', [id]);
+      if (rows.length === 0) {
+         return null;
+      }
       return this.rowToIEnvironment(rows[0]);
    }
 
-   public async makeEnvironment(environment: data.IEnvironment): Promise<data.IEnvironment> {
+   public async makeEnvironment(environment: data.IEnvironment): Promise<data.IEnvironment | null> {
       const row = await this.query<any>('INSERT INTO Environment SET ?', environment);
       return await this.getEnvironment(row.insertId);
    }

--- a/common/src/dao/replay-dao.ts
+++ b/common/src/dao/replay-dao.ts
@@ -9,12 +9,15 @@ export class ReplayDao extends Dao {
       return rawReplays.map(this.resultToIReplay);
    }
 
-   public async getReplay(id: number): Promise<data.IReplay> {
+   public async getReplay(id: number): Promise<data.IReplay | null> {
       const result = await this.query<any[]>('SELECT * FROM Replay WHERE id = ?', [id]);
+      if (result.length === 0) {
+         return null;
+      }
       return this.resultToIReplay(result[0]);
    }
 
-   public async makeReplay(replay: data.IReplay): Promise<data.IReplay> {
+   public async makeReplay(replay: data.IReplay): Promise<data.IReplay | null> {
       const result = await this.query<any>('INSERT INTO Replay SET ?', {
          name: replay.name,
          status: replay.status,

--- a/service/src/http-error.ts
+++ b/service/src/http-error.ts
@@ -5,7 +5,7 @@ export class HttpError extends Error {
    public readonly IS_HTTP_ERROR = true;
 
    constructor(public readonly code: number, message?: string) {
-      super(message);
+      super(message || http.getStatusText(code));
    }
 
 }

--- a/service/src/http-error.ts
+++ b/service/src/http-error.ts
@@ -1,0 +1,11 @@
+import * as http from 'http-status-codes';
+
+export class HttpError extends Error {
+
+   public readonly IS_HTTP_ERROR = true;
+
+   constructor(public readonly code: number, message?: string) {
+      super(message);
+   }
+
+}

--- a/service/src/middleware/request-validation.ts
+++ b/service/src/middleware/request-validation.ts
@@ -9,6 +9,7 @@ const logger = Logging.defaultLogger(__dirname);
 // https://medium.com/@skwee357/validating-requests-with-a-simple-middleware-for-express-ed20c5dfd35c
 
 export interface IErrorItem {
+   code?: number;
    message: string;
    path?: string[];
 }

--- a/service/src/routes/capture.ts
+++ b/service/src/routes/capture.ts
@@ -125,12 +125,16 @@ export default class CaptureRouter extends SelfAwareRouter {
       }));
 
       this.router.delete('/:id(\\d+)', check.validParams(schema.idParams),
-            this.tryCatch500(async (request, response) => {
+            this.handleHttpErrors(async (request, response) => {
 
-            const id = request.params.id;
-            const capture = await captureDao.deleteCapture(id);
-            response.json(capture);
-         }));
+         const id = request.params.id;
+         const capture = await captureDao.deleteCapture(id);
+         if (!capture) {
+            throw new HttpError(http.NOT_FOUND);
+         }
+         response.json(capture);
+
+      }));
 
    }
 }

--- a/service/src/routes/capture.ts
+++ b/service/src/routes/capture.ts
@@ -34,11 +34,10 @@ export default class CaptureRouter extends SelfAwareRouter {
 
          const id = request.params.id;
          const capture = await captureDao.getCapture(id);
-         if (capture === null) {
+         if (!capture) {
             throw new HttpError(http.NOT_FOUND);
-         } else {
-            response.json(capture);
          }
+         response.json(capture);
 
       }));
 

--- a/service/src/routes/environment.ts
+++ b/service/src/routes/environment.ts
@@ -15,18 +15,20 @@ export default class EnvironmentRouter extends SelfAwareRouter {
    protected mountRoutes(): void {
       const logger = Logging.defaultLogger(__dirname);
 
-      this.router.get('/', this.tryCatch500(async (request, response) => {
+      this.router.get('/', this.handleHttpErrors(async (request, response) => {
          const environments = await environmentDao.getAllEnvironments();
          response.json(environments);
       }));
 
-      this.router.get('/:id(\\d+)', check.validParams(schema.idParams), this.tryCatch500(async (request, response) => {
+      this.router.get('/:id(\\d+)', check.validParams(schema.idParams),
+            this.handleHttpErrors(async (request, response) => {
          const id = request.params.id;
          const environment = await environmentDao.getEnvironment(id);
          response.json(environment);
       }));
 
-      this.router.post('/', check.validBody(schema.environmentBody), this.tryCatch500(async (request, response) => {
+      this.router.post('/', check.validBody(schema.environmentBody),
+            this.handleHttpErrors(async (request, response) => {
 
          let iamReference: data.IIamReference = {
             accessKey: request.body.accessKey,

--- a/service/src/routes/ping.ts
+++ b/service/src/routes/ping.ts
@@ -9,7 +9,7 @@ export default class PingRouter extends SelfAwareRouter {
 
    protected mountRoutes(): void {
 
-      this.router.get('/', this.tryCatch500(async (request, response) => {
+      this.router.get('/', this.handleHttpErrors(async (request, response) => {
          response.status(http.OK).end();
       }));
 

--- a/service/src/routes/replay.ts
+++ b/service/src/routes/replay.ts
@@ -16,18 +16,19 @@ export default class ReplayRouter extends SelfAwareRouter {
    protected mountRoutes(): void {
       const logger = Logging.defaultLogger(__dirname);
 
-      this.router.get('/', this.tryCatch500(async (request, response) => {
+      this.router.get('/', this.handleHttpErrors(async (request, response) => {
          const replays = await replayDao.getAllReplays();
          response.json(replays);
       }));
 
-      this.router.get('/:id(\\d+)', check.validParams(schema.idParams), this.tryCatch500(async (request, response) => {
+      this.router.get('/:id(\\d+)', check.validParams(schema.idParams),
+            this.handleHttpErrors(async (request, response) => {
          const id = request.params.id;
          const replay = await replayDao.getReplay(id);
          response.json(replay);
       }));
 
-      this.router.post('/', check.validBody(schema.replayBody), this.tryCatch500(async (request, response) => {
+      this.router.post('/', check.validBody(schema.replayBody), this.handleHttpErrors(async (request, response) => {
 
          const replayTemplate: IReplay = {
             name: request.body.name,

--- a/service/src/routes/replay.ts
+++ b/service/src/routes/replay.ts
@@ -4,6 +4,7 @@ import { ChildProgramStatus, ChildProgramType, IReplay, Logging } from '@lbt-myc
 import { launch, ReplayConfig } from '@lbt-mycrt/replay';
 
 import { replayDao } from '../dao/mycrt-dao';
+import { HttpError } from '../http-error';
 import * as check from '../middleware/request-validation';
 import * as schema from '../request-schema/replay-schema';
 import { settings } from '../settings';
@@ -17,15 +18,22 @@ export default class ReplayRouter extends SelfAwareRouter {
       const logger = Logging.defaultLogger(__dirname);
 
       this.router.get('/', this.handleHttpErrors(async (request, response) => {
+
          const replays = await replayDao.getAllReplays();
          response.json(replays);
+
       }));
 
       this.router.get('/:id(\\d+)', check.validParams(schema.idParams),
             this.handleHttpErrors(async (request, response) => {
+
          const id = request.params.id;
          const replay = await replayDao.getReplay(id);
+         if (!replay) {
+            throw new HttpError(http.NOT_FOUND);
+         }
          response.json(replay);
+
       }));
 
       this.router.post('/', check.validBody(schema.replayBody), this.handleHttpErrors(async (request, response) => {
@@ -39,8 +47,8 @@ export default class ReplayRouter extends SelfAwareRouter {
 
          const replay = await replayDao.makeReplay(replayTemplate);
 
-         logger.info(`Launching replay with id ${replay.id!} for capture ${replay.captureId!}`);
-         const config = new ReplayConfig(replay.id!, replay.captureId!);
+         logger.info(`Launching replay with id ${replay!.id!} for capture ${replay!.captureId!}`);
+         const config = new ReplayConfig(replay!.id!, replay!.captureId!);
          config.mock = settings.replays.mock;
          config.interval = settings.replays.interval;
          config.intervalOverlap = settings.replays.intervalOverlap;

--- a/service/src/routes/self-aware-router.ts
+++ b/service/src/routes/self-aware-router.ts
@@ -42,7 +42,7 @@ export default abstract class SelfAwareRouter {
                info = {code: httpError.code, message: httpError.message};
                response.status(httpError.code).json(info);
             } else {
-               info = {code: http.INTERNAL_SERVER_ERROR, message: error};
+               info = {code: http.INTERNAL_SERVER_ERROR, message: error.message || error};
                response.status(http.INTERNAL_SERVER_ERROR).json(info);
             }
 

--- a/service/src/routes/self-aware-router.ts
+++ b/service/src/routes/self-aware-router.ts
@@ -4,6 +4,7 @@ import * as joi from 'joi';
 
 import { Logging, ServerIpcNode } from '@lbt-mycrt/common';
 
+import { HttpError } from '../http-error';
 import { IErrorItem } from '../middleware/request-validation';
 
 const logger = Logging.defaultLogger(__dirname);
@@ -21,14 +22,30 @@ export default abstract class SelfAwareRouter {
 
    protected abstract mountRoutes(): void;
 
-   protected tryCatch500(handler: RequestHandler): RequestHandler {
-      return (request, response, next) => {
+   protected handleHttpErrors(handler: RequestHandler): RequestHandler {
+      return async (request, response, next) => {
+
+         [['params', request.params], ['query ', request.query], ['body  ', request.body]].forEach((value) => {
+            if (Object.keys(value[1]).length) {
+               logger.info("request." + value[0] + " = " + JSON.stringify(value[1]));
+            }
+         });
+
          try {
-            handler(request, response, next);
+            await handler(request, response, next);
          } catch (error) {
             logger.error(error);
-            const info: IErrorItem = {message: error};
-            response.status(http.INTERNAL_SERVER_ERROR).json(info);
+            let info: IErrorItem;
+
+            if (error.IS_HTTP_ERROR === true) {
+               const httpError = error as HttpError;
+               info = {code: httpError.code, message: httpError.message};
+               response.status(httpError.code).json(info);
+            } else {
+               info = {code: http.INTERNAL_SERVER_ERROR, message: error};
+               response.status(http.INTERNAL_SERVER_ERROR).json(info);
+            }
+
          }
       };
    }

--- a/service/src/test/http-error.test.ts
+++ b/service/src/test/http-error.test.ts
@@ -1,0 +1,25 @@
+import { assert, expect } from 'chai';
+import * as http from 'http-status-codes';
+import 'mocha';
+
+import { HttpError } from '../http-error';
+
+describe("HttpError", () => {
+
+   it("should be identifiable when thrown", () => {
+      const msg = "NOT FOUND";
+      try {
+         throw new HttpError(http.NOT_FOUND, msg);
+      } catch (error) {
+         if (error.IS_HTTP_ERROR === true) {
+            assert.isTrue(true);
+            const httpError = error as HttpError;
+            expect(httpError.code).to.equal(http.NOT_FOUND);
+            expect(httpError.message).to.equal(msg);
+         } else {
+            assert.fail();
+         }
+      }
+   });
+
+});


### PR DESCRIPTION
added the ability to throw HttpError objects inside route endpoints. These objects have specific http error codes and the wrapping call (named handleHttpErrors) handles the request behavior when those errors are thrown.