### PR TITLE
address camerons code review

### DIFF
--- a/common/src/test/metrics/data.ts
+++ b/common/src/test/metrics/data.ts
@@ -27,6 +27,29 @@ export const time3 = "2018-01-30T02:46:00.000Z";
 export const time4 = "2018-01-30T02:47:00.000Z";
 export const time5 = "2018-01-30T02:48:00.000Z";
 
+export const metricsAllTypes: IMetricsList[] = [
+   {
+      label: "cpu",
+      type: MetricType.CPU,
+      dataPoints: [],
+   },
+   {
+      label: "memory",
+      type: MetricType.MEMORY,
+      dataPoints: [],
+   },
+   {
+      label: "read",
+      type: MetricType.READ,
+      dataPoints: [],
+   },
+   {
+      label: "write",
+      type: MetricType.WRITE,
+      dataPoints: [],
+   },
+];
+
 export const metricsA: IMetricsList[] = [
    {
       label: 'CPU label',

--- a/common/src/test/metrics/metrics-backend.test.ts
+++ b/common/src/test/metrics/metrics-backend.test.ts
@@ -98,10 +98,10 @@ describe("MetricsBackend", () => {
    it("should read all capture metrics", async () => {
       const result = await metrics.readMetrics(c1) as IMetricsList[];
       expect(result.length).to.equal(4);
-      const cpu = MetricsStorage.specificMetricFromList(result, MetricType.CPU);
-      const read = MetricsStorage.specificMetricFromList(result, MetricType.READ);
-      const write = MetricsStorage.specificMetricFromList(result, MetricType.WRITE);
-      const memory = MetricsStorage.specificMetricFromList(result, MetricType.MEMORY);
+      const cpu = MetricsStorage.getSpecificMetricFromList(result, MetricType.CPU);
+      const read = MetricsStorage.getSpecificMetricFromList(result, MetricType.READ);
+      const write = MetricsStorage.getSpecificMetricFromList(result, MetricType.WRITE);
+      const memory = MetricsStorage.getSpecificMetricFromList(result, MetricType.MEMORY);
       expect(cpu.type).to.equal(MetricType.CPU);
       expect(read.type).to.equal(MetricType.READ);
       expect(write.type).to.equal(MetricType.WRITE);

--- a/common/src/test/metrics/metrics-storage.test.ts
+++ b/common/src/test/metrics/metrics-storage.test.ts
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import * as data from '../../data';
+import { MetricsStorage } from '../../metrics/metrics-storage';
+
+import { metricsAllTypes } from './data';
+
+describe("MetricsStorage", () => {
+
+   const date = new Date(100200300);
+   const capture: data.ICapture = {
+      type: data.ChildProgramType.CAPTURE,
+      id: 100,
+   };
+
+   it("should get the root prefix", () => {
+      const actual = MetricsStorage.getRootPrefix(capture);
+      const expected = "capture100/";
+      expect(actual).to.equal(expected);
+   });
+
+   it("should get the depot prefix", () => {
+      const actual = MetricsStorage.getDepotPrefix(capture);
+      const expected = "capture100/depot/";
+      expect(actual).to.equal(expected);
+   });
+
+   it("should get the done metrics key", () => {
+      const actual = MetricsStorage.getDoneMetricsKey(capture);
+      const expected = "capture100/metrics.json";
+      expect(actual).to.equal(expected);
+   });
+
+   it("should get an in-progress metrics key", () => {
+      const actual = MetricsStorage.getInProgressMetricsKey(capture, date);
+      const expected = "capture100/metrics-100200300.json";
+      expect(actual).to.equal(expected);
+   });
+
+   it("should get a single sample metrics key", () => {
+      const actual = MetricsStorage.getSingleSampleMetricsKey(capture, date);
+      const expected = "capture100/depot/metrics-100200300.json";
+      expect(actual).to.equal(expected);
+   });
+
+   it("should get the correct metrics from a list", () => {
+      [data.MetricType.CPU, data.MetricType.MEMORY, data.MetricType.READ, data.MetricType.WRITE]
+            .forEach((type) => {
+         const metrics = MetricsStorage.getSpecificMetricFromList(metricsAllTypes, type);
+         expect(metrics.type).to.equal(type);
+      });
+   });
+
+});


### PR DESCRIPTION
- adjusted schema key retrieval methods to rely on broader prefixes, no more DRY
- rename function to have consistent naming 
- handle null case for getting a type string
- remove type redundancies
- refactor await in if statement to be more readable
- call existing function 
- throw error when multiple IMetricsList of same type are found.