### PR TITLE
Replace metrics hardcoding with env params

### DIFF
--- a/capture/src/main.ts
+++ b/capture/src/main.ts
@@ -14,6 +14,8 @@ import { Capture } from './capture';
 import { environmentDao } from './dao';
 
 const DBIdentifier: string = 'DBInstanceIdentifier';
+const period: number = 60;
+const statistics: string[] = ['Maximum'];
 
 async function runCapture(): Promise<void> {
    const logger = Logging.defaultLogger(__dirname);
@@ -30,7 +32,7 @@ async function runCapture(): Promise<void> {
          );
          const metrics = new CloudWatchMetricsBackend(
             new CloudWatch({region: env.region, accessKeyId: env.accessKey, secretAccessKey: env.secretKey}),
-            DBIdentifier, env.instance, 60, ['Maximum'],
+            DBIdentifier, env.instance, period, statistics,
          );
          return new Capture(config, storage, metrics, env);
       };

--- a/common/src/dao/capture-dao.ts
+++ b/common/src/dao/capture-dao.ts
@@ -49,6 +49,7 @@ export class CaptureDao extends Dao {
          start: captureData.start,
          end: captureData.end,
          status: captureData.status,
+         envId: captureData.envId,
          type: data.ChildProgramType.CAPTURE,
       };
    }

--- a/common/src/data.ts
+++ b/common/src/data.ts
@@ -24,6 +24,7 @@ export interface IChildProgram {
 
 export interface ICapture extends IChildProgram {
    type: ChildProgramType.CAPTURE;
+   envId?: number;
 }
 
 export interface IReplay extends IChildProgram {

--- a/replay/src/dao.ts
+++ b/replay/src/dao.ts
@@ -1,7 +1,9 @@
-import { ConnectionPool, ReplayDao } from '@lbt-mycrt/common';
+import { CaptureDao, ConnectionPool, EnvironmentDao, ReplayDao } from '@lbt-mycrt/common';
 
 // tslint:disable-next-line:no-var-requires
 const poolConfig = require('../db/config.json');
 const pool = new ConnectionPool(poolConfig);
 
+export const captureDao: CaptureDao = new CaptureDao(pool);
+export const environmentDao: EnvironmentDao = new EnvironmentDao(pool);
 export const replayDao: ReplayDao = new ReplayDao(pool);

--- a/replay/src/main.ts
+++ b/replay/src/main.ts
@@ -2,6 +2,8 @@
 
 import { CloudWatch, S3 } from 'aws-sdk';
 
+import { captureDao, environmentDao } from './dao';
+
 import { CloudWatchMetricsBackend, Logging, MetricsBackend, MockMetricsBackend } from '@lbt-mycrt/common';
 import { StorageBackend } from '@lbt-mycrt/common/dist/storage/backend';
 import { LocalBackend } from '@lbt-mycrt/common/dist/storage/local-backend';
@@ -11,32 +13,48 @@ import { getSandboxPath } from '@lbt-mycrt/common/dist/storage/sandbox';
 import { ReplayConfig } from './args';
 import { Replay } from './replay';
 
-if (typeof(require) !== 'undefined' && require.main === module) {
+const DBIdentifier: string = 'DBInstanceIdentifier';
+const period: number = 60;
+const statistics: string[] = ['Maximum'];
 
+async function runReplay(): Promise<void> {
    const logger = Logging.defaultLogger(__dirname);
 
    logger.info("Configuring MyCRT Replay Program");
    const config = ReplayConfig.fromCmdArgs();
    logger.info(config.toString());
 
-   const buildReplay = (): Replay => {
-      const storage = new S3Backend(new S3(), 'lil-test-environment'); // TODO: get bucket name from the environment
-      const metrics = new CloudWatchMetricsBackend(new CloudWatch({region: 'us-east-2'}), 'DBInstanceIdentifier',
-         'nfl2015', 60, ['Maximum']);
-      return new Replay(config, storage, metrics);
-   };
+   const capture = await captureDao.getCapture(config.captureId);
+   if (capture && capture.envId) {
+      const env = await environmentDao.getEnvironmentFull(capture.envId);
+      if (env) {
+         const buildReplay = (): Replay => {
+            const storage = new S3Backend(
+               new S3({region: env.region, accessKeyId: env.accessKey, secretAccessKey: env.secretKey}), env.bucket,
+            );
+            const metrics = new CloudWatchMetricsBackend(
+               new CloudWatch({region: env.region, accessKeyId: env.accessKey, secretAccessKey: env.secretKey}),
+               DBIdentifier, env.instance, period, statistics,
+            );
+            return new Replay(config, storage, metrics);
+         };
 
-   const buildMockReplay = (): Replay => {
-      const storage = new LocalBackend(getSandboxPath());
-      const metrics = new MockMetricsBackend(5);
-      return new Replay(config, storage, metrics);
-   };
+         const buildMockReplay = (): Replay => {
+            const storage = new LocalBackend(getSandboxPath());
+            const metrics = new MockMetricsBackend(5);
+            return new Replay(config, storage, metrics);
+         };
 
-   const replay = config.mock ? buildMockReplay() : buildReplay();
+         const replay = config.mock ? buildMockReplay() : buildReplay();
 
-   logger.info("Running MyCRT Replay Program");
-   replay.run();
+         logger.info("Running MyCRT Replay Program");
+         replay.run();
+      }
+   }
+}
 
+if (typeof(require) !== 'undefined' && require.main === module) {
+    runReplay();
 }
 
 export { launch } from './launch';


### PR DESCRIPTION
Refactored replay's main.ts to use the associated environment parameters instead of hardcoded data when creating a new Cloudwatch instance for CloudWatchMetricsBackend. 