### PR TITLE
Refactored metrics based on code review notes

### DIFF
--- a/capture/src/capture.ts
+++ b/capture/src/capture.ts
@@ -2,7 +2,7 @@ import mysql = require('mysql');
 import { setTimeout } from 'timers';
 
 import { CaptureIpcNode, ICaptureIpcNodeDelegate, IpcNode, Logging } from '@lbt-mycrt/common';
-import { MetricsBackend } from '@lbt-mycrt/common';
+import { CPUMetric, MemoryMetric, Metric, MetricsBackend, ReadMetric, WriteMetric } from '@lbt-mycrt/common';
 import { Subprocess } from '@lbt-mycrt/common/dist/capture-replay/subprocess';
 import { ChildProgramStatus, ChildProgramType, IChildProgram, IEnvironment,
    IEnvironmentFull } from '@lbt-mycrt/common/dist/data';
@@ -130,10 +130,10 @@ export class Capture extends Subprocess implements ICaptureIpcNodeDelegate {
       try {
 
          const data = [
-            await this.metrics.getCPUMetrics(start, end),
-            await this.metrics.getReadMetrics(start, end),
-            await this.metrics.getWriteMetrics(start, end),
-            await this.metrics.getMemoryMetrics(start, end),
+            await this.metrics.getMetricsForType(CPUMetric, start, end),
+            await this.metrics.getMetricsForType(ReadMetric, start, end),
+            await this.metrics.getMetricsForType(WriteMetric, start, end),
+            await this.metrics.getMetricsForType(MemoryMetric, start, end),
          ];
 
          const key = MetricsStorage.getSingleSampleMetricsKey(this.asIChildProgram(), end);

--- a/common/src/data.ts
+++ b/common/src/data.ts
@@ -1,4 +1,3 @@
-
 export enum ChildProgramType { CAPTURE = 'CAPTURE', REPLAY = 'REPLAY' }
 
 /** The status of a capture/replay */
@@ -97,7 +96,7 @@ export interface IMetric {
 /** Interface for a list of a IMetrics gathered at different timestamps for a capture/replay */
 export interface IMetricsList {
    label: string;
-   type: MetricType;
+   type: string;
    displayName?: string;
    complete?: boolean;
    dataPoints: IMetric[];

--- a/common/src/main.ts
+++ b/common/src/main.ts
@@ -23,6 +23,7 @@ export * from './ipc/delegates/capture-delegate';
 export * from './ipc/delegates/replay-delegate';
 
 /* Metrics */
+export * from './metrics/metrics';
 export * from './metrics/metrics-storage';
 export * from './metrics/metrics-backend';
 export * from './metrics/mock-metrics-backend';

--- a/common/src/metrics/cloudwatch-metrics-backend.ts
+++ b/common/src/metrics/cloudwatch-metrics-backend.ts
@@ -1,6 +1,7 @@
 import { CloudWatch } from 'aws-sdk';
 
 import { IMetricsList } from '../data';
+import { Metric } from './metrics';
 import { MetricsBackend, toIMetricsList } from './metrics-backend';
 
 export class CloudWatchMetricsBackend extends MetricsBackend {
@@ -20,20 +21,21 @@ export class CloudWatchMetricsBackend extends MetricsBackend {
       this.statistics = statistics;
    }
 
-   protected getMetrics(metricName: string, unit: string, startTime: Date, endTime: Date): Promise<IMetricsList> {
+   protected getMetrics(metric: Metric, startTime: Date, endTime: Date): Promise<IMetricsList> {
       return new Promise<IMetricsList>((resolve, reject) => {
-         this.cloudwatch.getMetricStatistics(this.buildMetricRequest(metricName, unit, startTime, endTime),
+         this.cloudwatch.getMetricStatistics(this.buildMetricRequest(metric, startTime, endTime),
                (err, data) => {
             if (err) {
                reject(err.stack);
             } else {
-               resolve(toIMetricsList(data));
+               resolve(toIMetricsList(metric, data));
             }
          });
       });
    }
 
-   private buildMetricRequest(metricName: string, unit: string, startTime: Date, endTime: Date) {
+   private buildMetricRequest(metric: Metric, startTime: Date, endTime: Date):
+         CloudWatch.Types.GetMetricStatisticsInput {
       return {
          Dimensions: [
             {
@@ -42,12 +44,12 @@ export class CloudWatchMetricsBackend extends MetricsBackend {
             },
          ],
          EndTime: endTime,
-         MetricName: metricName,
+         MetricName: metric.metricName,
          Namespace: 'AWS/RDS',
          Period: this.period,
          StartTime: startTime,
          Statistics: this.statistics,
-         Unit: unit,
+         Unit: metric.unit,
       };
    }
 

--- a/common/src/metrics/metrics-backend.ts
+++ b/common/src/metrics/metrics-backend.ts
@@ -1,61 +1,24 @@
 import { CloudWatch } from 'aws-sdk';
 
 import { IMetricsList, MetricType } from '../data';
+import { Metric } from './metrics';
 
-// Metrics to retrieve
-export const CPU = 'CPUUtilization';
-export const READ = 'ReadLatency';
-export const WRITE = 'WriteLatency';
-export const MEMORY = 'FreeableMemory';
-
-export const cpuUnit = 'Percent';
-export const ioUnit = 'Seconds';
-export const memoryUnit = 'Bytes';
-
-export const nameToType = (name: string): MetricType => {
-   switch (name) {
-      case CPU:
-         return MetricType.CPU;
-      case READ:
-         return MetricType.READ;
-      case WRITE:
-         return MetricType.WRITE;
-      case MEMORY:
-         return MetricType.MEMORY;
-      default:
-         throw new Error(`Unknown metric name: ${name}`);
-   }
-};
-
-export const toIMetricsList = (data: CloudWatch.GetMetricStatisticsOutput): IMetricsList => {
-   const labelStr = data.Label || CPU;
+export const toIMetricsList = (metric: Metric, data: CloudWatch.GetMetricStatisticsOutput): IMetricsList => {
    return {
-      label: labelStr,
-      type: nameToType(labelStr),
-      displayName: nameToType(labelStr),
+      label: metric.metricName,
+      type: metric.metricType,
+      displayName: metric.metricType,
       dataPoints: (data.Datapoints || []) as any,
    };
 };
 
 export abstract class MetricsBackend {
 
-   public getCPUMetrics(startTime: Date, endTime: Date) {
-      return this.getMetrics(CPU, cpuUnit, startTime, endTime);
+   public getMetricsForType(metric: Metric, startTime: Date, endTime: Date) {
+      return this.getMetrics(metric, startTime, endTime);
    }
 
-   public getReadMetrics(startTime: Date, endTime: Date) {
-      return this.getMetrics(READ, ioUnit, startTime, endTime);
-   }
-
-   public getWriteMetrics(startTime: Date, endTime: Date) {
-      return this.getMetrics(WRITE, ioUnit, startTime, endTime);
-   }
-
-   public getMemoryMetrics(startTime: Date, endTime: Date) {
-      return this.getMetrics(MEMORY, memoryUnit, startTime, endTime);
-   }
-
-   protected abstract getMetrics(metricName: string, unit: string, startTime: Date, endTime: Date):
+   protected abstract getMetrics(metric: Metric, startTime: Date, endTime: Date):
       Promise<IMetricsList>;
 
 }

--- a/common/src/metrics/metrics.ts
+++ b/common/src/metrics/metrics.ts
@@ -1,0 +1,18 @@
+import { IMetricsList, MetricType } from '../data';
+
+export class Metric {
+    public metricType: string;
+    public metricName: string;
+    public unit: string;
+
+    constructor(metricType: string, metricName: string, unit: string) {
+        this.metricType = metricType;
+        this.metricName = metricName;
+        this.unit = unit;
+    }
+}
+
+export const CPUMetric = new Metric(MetricType.CPU, 'CPUUtilization', 'Percent');
+export const ReadMetric = new Metric(MetricType.READ, 'ReadLatency', 'Seconds');
+export const WriteMetric = new Metric(MetricType.WRITE, 'WriteLatency', 'Seconds');
+export const MemoryMetric = new Metric(MetricType.MEMORY, 'FreeableMemory', 'Bytes');

--- a/common/src/metrics/mock-metrics-backend.ts
+++ b/common/src/metrics/mock-metrics-backend.ts
@@ -1,6 +1,6 @@
 import { IMetric, IMetricsList, MetricType } from '../data';
+import { Metric } from './metrics';
 import { MetricsBackend } from './metrics-backend';
-import { CPU, MEMORY, READ, WRITE } from './metrics-backend';
 
 /**
  * Produce dummy data for catpures/replays running in a mock mode.
@@ -14,34 +14,34 @@ export class MockMetricsBackend extends MetricsBackend {
       this.period = period;
    }
 
-   protected async getMetrics(metricName: string, unit: string, startTime: Date, endTime: Date): Promise<IMetricsList> {
+   protected async getMetrics(metric: Metric, startTime: Date, endTime: Date): Promise<IMetricsList> {
       // min/max values were approximated from metrics samples
-      switch (metricName) {
-         case CPU:
-            return this.makeMockData(metricName, MetricType.CPU, unit, 3.0, 6.0, startTime, endTime);
-         case READ:
-            return this.makeMockData(metricName, MetricType.READ, unit, 510000000, 540000000, startTime, endTime);
-         case WRITE:
-            return this.makeMockData(metricName, MetricType.WRITE, unit, 510000000, 540000000, startTime, endTime);
-         case MEMORY:
-            return this.makeMockData(metricName, MetricType.MEMORY, unit, 0, 0.003, startTime, endTime);
+      switch (metric.metricType) {
+         case MetricType.CPU:
+            return this.makeMockData(metric, 3.0, 6.0, startTime, endTime);
+         case MetricType.READ:
+            return this.makeMockData(metric, 510000000, 540000000, startTime, endTime);
+         case MetricType.WRITE:
+            return this.makeMockData(metric, 510000000, 540000000, startTime, endTime);
+         case MetricType.MEMORY:
+            return this.makeMockData(metric, 0, 0.003, startTime, endTime);
          default:
-            throw new Error(`Unknown metricName: ${metricName}`);
+            throw new Error(`Unknown metricName: ${metric.metricType}`);
       }
    }
 
-   private makeMockData(label: string, type: MetricType, unit: string, minVal: number, maxVal: number, startTime: Date,
+   private makeMockData(metric: Metric, minVal: number, maxVal: number, startTime: Date,
          endTime: Date): IMetricsList {
       const list: IMetric[] = [];
       for (const cur = new Date(startTime.getTime()); cur < endTime; cur.setSeconds(cur.getSeconds() + this.period)) {
          const val: number = Math.random() * (maxVal - minVal) + minVal;
-         list.push(this.makeMockDataPoint(cur, unit, val));
+         list.push(this.makeMockDataPoint(cur, metric.unit, val));
       }
 
       return {
-         label,
-         type,
-         displayName: label,
+         label: metric.metricName,
+         type: metric.metricType,
+         displayName: metric.metricName,
          dataPoints: list,
       };
    }

--- a/common/src/test/metrics/data.ts
+++ b/common/src/test/metrics/data.ts
@@ -1,23 +1,23 @@
 import { IMetricsList, MetricType } from '../../data';
-import { CPU, MEMORY, READ, WRITE } from '../../main';
+import { CPUMetric, MemoryMetric, ReadMetric, WriteMetric } from '../../main';
 
 export const dummyCPU = {
-    Label: CPU,
+    Label: CPUMetric.metricName,
     Datapoints: [],
 };
 
 export const dummyMemory = {
-    Label: MEMORY,
+    Label: MemoryMetric.metricName,
     Datapoints: [],
 };
 
 export const dummyRead = {
-    Label: READ,
+    Label: ReadMetric.metricName,
     Datapoints: [],
 };
 
 export const dummyWrite = {
-    Label: WRITE,
+    Label: WriteMetric.metricName,
     Datapoints: [],
 };
 

--- a/common/src/test/metrics/metrics.test.ts
+++ b/common/src/test/metrics/metrics.test.ts
@@ -2,7 +2,7 @@ import { CloudWatch } from 'aws-sdk';
 import { expect } from 'chai';
 import 'mocha';
 import mockito from 'ts-mockito';
-import { CloudWatchMetricsBackend, CPU, MEMORY, READ, WRITE } from '../../main';
+import { CloudWatchMetricsBackend, CPUMetric, MemoryMetric, Metric, ReadMetric, WriteMetric } from '../../main';
 import { dummyCPU, dummyMemory, dummyRead, dummyWrite } from './data';
 
 import Logging = require('./../../logging');
@@ -30,7 +30,7 @@ describe("CloudwatchMetricsBackend", () => {
             } as CloudWatch.GetMetricStatisticsOutput);
         });
 
-        await metrics.getCPUMetrics(new Date(), new Date())
+        await metrics.getMetricsForType(CPUMetric, new Date(), new Date())
          .then((cpuMetrics) => {
             expect(cpuMetrics.label).to.equal(dummyCPU.Label);
             expect(cpuMetrics.dataPoints).to.deep.equal(dummyCPU.Datapoints);
@@ -47,7 +47,7 @@ describe("CloudwatchMetricsBackend", () => {
             } as CloudWatch.GetMetricStatisticsOutput);
         });
 
-        await metrics.getReadMetrics(new Date(), new Date())
+        await metrics.getMetricsForType(ReadMetric, new Date(), new Date())
          .then((readMetrics) => {
             expect(readMetrics.label).to.equal(dummyRead.Label);
             expect(readMetrics.dataPoints).to.deep.equal(dummyRead.Datapoints);
@@ -64,7 +64,7 @@ describe("CloudwatchMetricsBackend", () => {
             } as CloudWatch.GetMetricStatisticsOutput);
         });
 
-        await metrics.getWriteMetrics(new Date(), new Date())
+        await metrics.getMetricsForType(WriteMetric, new Date(), new Date())
          .then((writeMetrics) => {
             expect(writeMetrics.label).to.equal(dummyWrite.Label);
             expect(writeMetrics.dataPoints).to.deep.equal(dummyWrite.Datapoints);
@@ -81,7 +81,7 @@ describe("CloudwatchMetricsBackend", () => {
                 } as CloudWatch.GetMetricStatisticsOutput);
             });
 
-        await metrics.getMemoryMetrics(new Date(), new Date())
+        await metrics.getMetricsForType(MemoryMetric, new Date(), new Date())
          .then((memoryMetrics) => {
             expect(memoryMetrics.label).to.equal(dummyMemory.Label);
             expect(memoryMetrics.dataPoints).to.deep.equal(dummyMemory.Datapoints);
@@ -95,7 +95,7 @@ describe("CloudwatchMetricsBackend", () => {
             callback("cpu metrics do not exist", null);
         });
 
-        const cpuMetrics = await metrics.getCPUMetrics(new Date(), new Date())
+        const cpuMetrics = await metrics.getMetricsForType(CPUMetric, new Date(), new Date())
          .catch((reason) => {
             expect(reason).to.not.be.null;
          });
@@ -107,7 +107,7 @@ describe("CloudwatchMetricsBackend", () => {
             callback("read (io) metrics do not exist", null);
         });
 
-        const readMetrics = await metrics.getReadMetrics(new Date(), new Date())
+        const readMetrics = await metrics.getMetricsForType(ReadMetric, new Date(), new Date())
          .catch((reason) => {
             expect(reason).to.not.be.null;
          });
@@ -119,7 +119,7 @@ describe("CloudwatchMetricsBackend", () => {
             callback("write (io) metrics do not exist", null);
         });
 
-        const writeMetrics = await metrics.getWriteMetrics(new Date(), new Date())
+        const writeMetrics = await metrics.getMetricsForType(WriteMetric, new Date(), new Date())
          .catch((reason) => {
             expect(reason).to.not.be.null;
          });
@@ -131,7 +131,7 @@ describe("CloudwatchMetricsBackend", () => {
             callback("memory metrics do not exist", null);
         });
 
-        const memoryMetrics = await metrics.getMemoryMetrics(new Date(), new Date())
+        const memoryMetrics = await metrics.getMetricsForType(MemoryMetric, new Date(), new Date())
          .catch((reason) => {
             expect(reason).to.not.be.null;
          });

--- a/replay/src/replay.ts
+++ b/replay/src/replay.ts
@@ -2,7 +2,7 @@ import mysql = require('mysql');
 
 import { ICapture, IpcNode, IReplayIpcNodeDelegate, Logging } from '@lbt-mycrt/common';
 import { mycrtDbConfig, ReplayDao, ReplayIpcNode } from '@lbt-mycrt/common';
-import { MetricsBackend } from '@lbt-mycrt/common';
+import { CPUMetric, MemoryMetric, MetricsBackend, ReadMetric, WriteMetric } from '@lbt-mycrt/common';
 import { Subprocess } from '@lbt-mycrt/common/dist/capture-replay/subprocess';
 import { ChildProgramStatus, ChildProgramType, IChildProgram, IDbReference } from '@lbt-mycrt/common/dist/data';
 import { MetricsStorage } from '@lbt-mycrt/common/dist/metrics/metrics-storage';
@@ -225,10 +225,10 @@ export class Replay extends Subprocess implements IReplayIpcNodeDelegate {
       try {
 
          const data = [
-            await this.metrics.getCPUMetrics(start, end),
-            await this.metrics.getReadMetrics(start, end),
-            await this.metrics.getWriteMetrics(start, end),
-            await this.metrics.getMemoryMetrics(start, end),
+            await this.metrics.getMetricsForType(CPUMetric, start, end),
+            await this.metrics.getMetricsForType(ReadMetric, start, end),
+            await this.metrics.getMetricsForType(WriteMetric, start, end),
+            await this.metrics.getMetricsForType(MemoryMetric, start, end),
          ];
 
          const key = MetricsStorage.getSingleSampleMetricsKey(this.asIChildProgram(), end);


### PR DESCRIPTION
- Made a metric interface in order to make some constants for CPU, Memory, and IO metrics
- Instead of four different get___Metrics methods, made a single getMetricsForType method that takes a metric type. This should allow for easier metric extension if MyCRT is ever decided to be compatible with more metric types
- Specify return type on buildMetricRequest (in cloudwatch-metrics-backend)
- Refactored code to account for above changes