### PR TITLE
Memory metrics are now in megabytes instead of bytes

### DIFF
--- a/capture/src/capture.ts
+++ b/capture/src/capture.ts
@@ -4,7 +4,7 @@ import { setTimeout } from 'timers';
 import { CaptureIpcNode, ICaptureIpcNodeDelegate, IpcNode, Logging } from '@lbt-mycrt/common';
 import { CPUMetric, MemoryMetric, Metric, MetricsBackend, ReadMetric, WriteMetric } from '@lbt-mycrt/common';
 import { Subprocess } from '@lbt-mycrt/common/dist/capture-replay/subprocess';
-import { ChildProgramStatus, ChildProgramType, IChildProgram, IEnvironment,
+import { ByteToMegabyte, ChildProgramStatus, ChildProgramType, IChildProgram, IEnvironment,
    IEnvironmentFull } from '@lbt-mycrt/common/dist/data';
 import { MetricsStorage } from '@lbt-mycrt/common/dist/metrics/metrics-storage';
 import { StorageBackend } from '@lbt-mycrt/common/dist/storage/backend';
@@ -150,11 +150,20 @@ export class Capture extends Subprocess implements ICaptureIpcNodeDelegate {
 
    private async sendMetricsToS3(start: Date, end: Date) {
       this.tryTwice(async () => {
+
+         const memoryMetrics = await this.metrics.getMetricsForType(MemoryMetric, start, end);
+         const datapoints = memoryMetrics.dataPoints;
+
+         datapoints.forEach((metric) => {
+            metric.Unit = "Megabytes";
+            metric.Maximum *= ByteToMegabyte;
+         });
+
          const data = [
             await this.metrics.getMetricsForType(CPUMetric, start, end),
             await this.metrics.getMetricsForType(ReadMetric, start, end),
             await this.metrics.getMetricsForType(WriteMetric, start, end),
-            await this.metrics.getMetricsForType(MemoryMetric, start, end),
+            memoryMetrics,
          ];
 
          const key = schema.metrics.getSingleSampleKey(this.asIChildProgram(), end);

--- a/common/src/data.ts
+++ b/common/src/data.ts
@@ -135,3 +135,5 @@ export interface IMetricsList {
    complete?: boolean;
    dataPoints: IMetric[];
 }
+
+export const ByteToMegabyte = 0.00000095367432;


### PR DESCRIPTION
Loop through the data points returned by the CloudWatch FreeableMemory request and change the unit to megabytes and the values from bytes to megabytes.

This will allow memory metric values to be more user-friendly.