### PR TITLE
S3 info bug fix

### DIFF
--- a/gui/src/pages/capture.tsx
+++ b/gui/src/pages/capture.tsx
@@ -269,7 +269,8 @@ class CaptureApp extends React.Component<any, any> {
                   </div>
                   <div className="tab-pane" id="replays" role="tabpanel">
                      {this.state.replayObj ?
-                        <ReplayInfo replay={this.state.replayObj} envId={this.state.envId}/> : null
+                        <ReplayInfo replay={this.state.replayObj} bucket={this.state.env.bucket}
+                        envId={this.state.envId}/> : null
                      }<br/>
                      <div className="page-header"><h2>Replays</h2><br/></div>
                      <div className="myCRT-overflow-col">

--- a/gui/src/pages/components/capture_info_comp.tsx
+++ b/gui/src/pages/components/capture_info_comp.tsx
@@ -34,10 +34,15 @@ export class CaptureInfo extends React.Component<any, any>  {
                         {this.formatTimeStamp(this.props.capture.end)}
                      </label><br/><br/>
                   </div>
-                  <div className="col-xs-6" style={{padding: "20px 60px 0px"}}>
+                  <div className="col-xs-6" style={{padding: "20px 20px 0px"}}>
                      <h5>Source Database:</h5>
                      <label><b>&nbsp;&nbsp;&nbsp;Name: </b>{this.props.env.dbName}</label><br/>
                      <label><b>&nbsp;&nbsp;&nbsp;Host: </b>{this.props.env.host}</label><br/><br/>
+                  </div>
+                  <div className="col-xs-6" style={{padding: "20px 20px 0px"}}>
+                     <h5>S3 File Storage:</h5>
+                     <label><b>&nbsp;&nbsp;&nbsp;Bucket: </b>{this.props.env.bucket}</label><br/>
+                     <label><b>&nbsp;&nbsp;&nbsp;Folder: </b>{"capture" + this.props.capture.id}</label><br/><br/>
                   </div>
                </div>
             </div>

--- a/gui/src/pages/components/replay_info_comp.tsx
+++ b/gui/src/pages/components/replay_info_comp.tsx
@@ -43,11 +43,16 @@ export class ReplayInfo extends React.Component<any, any>  {
                         {this.formatTimeStamp(this.props.replay.end)}
                      </label><br/><br/>
                   </div>
-                  <div className="col-xs-6" style={{padding: "20px 60px 0px"}}>
+                  <div className="col-xs-6" style={{padding: "20px 20px 0px"}}>
                      <h5>Target Database:</h5>
                      <label><b>&nbsp;&nbsp;&nbsp;Name: </b>{this.props.replay.db.name}</label><br/>
                      <label><b>&nbsp;&nbsp;&nbsp;Host: </b>{this.props.replay.db.host}</label><br/>
                      <label><b>&nbsp;&nbsp;&nbsp;User: </b>{this.props.replay.db.user}</label><br/><br/>
+                  </div>
+                  <div className="col-xs-6" style={{padding: "20px 20px 0px"}}>
+                     <h5>S3 File Storage:</h5>
+                     <label><b>&nbsp;&nbsp;&nbsp;Bucket: </b>{this.props.bucket}</label><br/>
+                     <label><b>&nbsp;&nbsp;&nbsp;Folder: </b>{"replay" + this.props.replay.id}</label><br/><br/>
                   </div>
                </div>
             </div>


### PR DESCRIPTION
Added S3 Storage information for the associated bucket and folder on both the Capture and Replay details pages to fulfill LIL-167 and LIL-176.