### PR TITLE
Add support for new cloudwatch metrics

### DIFF
--- a/common/src/data.ts
+++ b/common/src/data.ts
@@ -135,9 +135,9 @@ export interface IWorkload {
 }
 
 /** The type of data */
-export enum MetricType { CPU = "CPU Utilization", WRITE = "Write IOPS", READ = "Read IOPS", MEMORY = "Freeable Memory",
-                         FREESTORAGE = "Free Storage", READTHROUGHPUT = "Read Throughput",
-                         WRITETHROUGHPUT = "Write Throughput",
+export enum MetricType { CPU = "CPU UTILIZATION", WRITE = "WRITE IOPS", READ = "READ IOPS", MEMORY = "FREEABLE MEMORY",
+                         FREESTORAGE = "FREE STORAGE", READTHROUGHPUT = "READ THROUGHPUT",
+                         WRITETHROUGHPUT = "WRITE THROUGHPUT",
                        }
 
 /** Interface for a single metric measurement */

--- a/common/src/data.ts
+++ b/common/src/data.ts
@@ -135,7 +135,10 @@ export interface IWorkload {
 }
 
 /** The type of data */
-export enum MetricType { CPU = "CPU", WRITE = "WRITE", READ = "READ", MEMORY = "MEMORY" }
+export enum MetricType { CPU = "CPU Utilization", WRITE = "Write IOPS", READ = "Read IOPS", MEMORY = "Freeable Memory",
+                         FREESTORAGE = "Free Storage", READTHROUGHPUT = "Read Throughput",
+                         WRITETHROUGHPUT = "Write Throughput",
+                       }
 
 /** Interface for a single metric measurement */
 export interface IMetric {

--- a/common/src/metrics/metrics.ts
+++ b/common/src/metrics/metrics.ts
@@ -12,7 +12,28 @@ export class Metric {
     }
 }
 
-export const CPUMetric = new Metric(MetricType.CPU, 'CPUUtilization', 'Percent');
-export const ReadMetric = new Metric(MetricType.READ, 'ReadIOPS', 'Count/Second');
-export const WriteMetric = new Metric(MetricType.WRITE, 'WriteIOPS', 'Count/Second');
-export const MemoryMetric = new Metric(MetricType.MEMORY, 'FreeableMemory', 'Bytes');
+export interface IMetricsHash {
+   [name: string]: Metric;
+}
+
+const metricsHash: IMetricsHash = {};
+metricsHash[MetricType.CPU] = new Metric(MetricType.CPU, 'CPUUtilization', 'Percent');
+metricsHash[MetricType.READ] = new Metric(MetricType.READ, 'ReadIOPS', 'Count/Second');
+metricsHash[MetricType.WRITE] = new Metric(MetricType.WRITE, 'WriteIOPS', 'Count/Second');
+metricsHash[MetricType.MEMORY] = new Metric(MetricType.MEMORY, 'FreeableMemory', 'Bytes');
+metricsHash[MetricType.FREESTORAGE] = new Metric(MetricType.FREESTORAGE, 'FreeStorageSpace', 'Bytes');
+metricsHash[MetricType.WRITETHROUGHPUT] = new Metric(MetricType.WRITETHROUGHPUT, 'WriteThroughput', 'Bytes/Second');
+metricsHash[MetricType.READTHROUGHPUT] = new Metric(MetricType.READTHROUGHPUT, 'ReadThroughput', 'Bytes/Second');
+export const MetricsHash = metricsHash;
+
+/* Potential future metric types?
+metricsHash[MetricType.BINLOGDISK] = new Metric(MetricType.BINLOGDISK, 'BinLogDiskUsage', 'Bytes');
+metricsHash[MetricType.BURST] = new Metric(MetricType.BURST, 'BurstBalance', 'Percent');
+metricsHash[MetricType.DBCONNECTIONS] = new Metric(MetricType.DBCONNECTIONS, 'DatabaseConnections', 'Count');
+metricsHash[MetricType.DISKQUEUE] = new Metric(MetricType.DISKQUEUE, 'DiskQueueDepth', 'Count');
+metricsHash[MetricType.NETWORKIN] = new Metric(MetricType.NETWORKIN, 'NetworkReceiveThroughput', 'Bytes/Second');
+metricsHash[MetricType.NETWORKOUT] = new Metric(MetricType.NETWORKOUT, 'NetworkTransmitThroughput', 'Bytes/Second');
+metricsHash[MetricType.READLATENCY] = new Metric(MetricType.READLATENCY, 'ReadLatency', 'Seconds');
+metricsHash[MetricType.SWAPUSAGE] = new Metric(MetricType.SWAPUSAGE, 'SwapUsage', 'Bytes');
+metricsHash[MetricType.WRITELATENCY] = new Metric(MetricType.WRITELATENCY, 'WriteLatency', 'Seconds');
+*/

--- a/common/src/test/metrics/data.ts
+++ b/common/src/test/metrics/data.ts
@@ -1,5 +1,13 @@
 import { IMetricsList, MetricType } from '../../data';
-import { CPUMetric, MemoryMetric, ReadMetric, WriteMetric } from '../../main';
+import { MetricsHash } from '../../main';
+
+const CPUMetric = MetricsHash[MetricType.CPU];
+const ReadMetric = MetricsHash[MetricType.READ];
+const WriteMetric = MetricsHash[MetricType.WRITE];
+const MemoryMetric = MetricsHash[MetricType.MEMORY];
+const WriteThroughput = MetricsHash[MetricType.WRITETHROUGHPUT];
+const ReadThroughput = MetricsHash[MetricType.READTHROUGHPUT];
+const FreeStorage = MetricsHash[MetricType.FREESTORAGE];
 
 export const dummyCPU = {
     Label: CPUMetric.metricName,
@@ -19,6 +27,21 @@ export const dummyRead = {
 export const dummyWrite = {
     Label: WriteMetric.metricName,
     Datapoints: [],
+};
+
+export const dummyReadThroughput = {
+   Label: ReadThroughput.metricName,
+   Datapoints: [],
+};
+
+export const dummyWriteThroughput = {
+   Label: WriteThroughput.metricName,
+   Datapoints: [],
+};
+
+export const dummyFreeStorage = {
+   Label: FreeStorage.metricName,
+   Datapoints: [],
 };
 
 export const time1 = "2018-01-30T02:44:00.000Z";

--- a/common/src/test/metrics/metrics.test.ts
+++ b/common/src/test/metrics/metrics.test.ts
@@ -141,7 +141,7 @@ describe("CloudwatchMetricsBackend", () => {
             } as CloudWatch.GetMetricStatisticsOutput);
          });
 
-      await metrics.getMetricsForType(ReadThroughput, new Date(), new Date())
+      await metrics.getMetricsForType(FreeStorage, new Date(), new Date())
          .then((storageMetrics) => {
             expect(storageMetrics.label).to.equal(dummyFreeStorage.Label);
             expect(storageMetrics.dataPoints).to.deep.equal(dummyFreeStorage.Datapoints);

--- a/common/src/test/metrics/metrics.test.ts
+++ b/common/src/test/metrics/metrics.test.ts
@@ -2,139 +2,235 @@ import { CloudWatch } from 'aws-sdk';
 import { expect } from 'chai';
 import 'mocha';
 import mockito from 'ts-mockito';
-import { CloudWatchMetricsBackend, CPUMetric, MemoryMetric, Metric, ReadMetric, WriteMetric } from '../../main';
-import { dummyCPU, dummyMemory, dummyRead, dummyWrite } from './data';
+import { CloudWatchMetricsBackend, Metric, MetricsHash, MetricType } from '../../main';
+import { dummyCPU, dummyFreeStorage, dummyMemory, dummyRead, dummyReadThroughput,
+   dummyWrite, dummyWriteThroughput } from './data';
 
 import Logging = require('./../../logging');
 
 const logger = Logging.consoleLogger();
 
+const CPUMetric = MetricsHash[MetricType.CPU];
+const ReadMetric = MetricsHash[MetricType.READ];
+const WriteMetric = MetricsHash[MetricType.WRITE];
+const MemoryMetric = MetricsHash[MetricType.MEMORY];
+const WriteThroughput = MetricsHash[MetricType.WRITETHROUGHPUT];
+const ReadThroughput = MetricsHash[MetricType.READTHROUGHPUT];
+const FreeStorage = MetricsHash[MetricType.FREESTORAGE];
+
 describe("CloudwatchMetricsBackend", () => {
 
-    let cloudwatch: CloudWatch;
-    let spiedCloudwatch: CloudWatch;
-    let metrics: CloudWatchMetricsBackend;
+   let cloudwatch: CloudWatch;
+   let spiedCloudwatch: CloudWatch;
+   let metrics: CloudWatchMetricsBackend;
 
-    before(() => {
-        cloudwatch = new CloudWatch({ region: 'us-east-2' });
-        spiedCloudwatch = mockito.spy(cloudwatch);
-        metrics = new CloudWatchMetricsBackend(cloudwatch, 'DBInstanceIdentifier', 'nfl2015', 60, ['Maximum']);
-    });
+   before(() => {
+      cloudwatch = new CloudWatch({ region: 'us-east-2' });
+      spiedCloudwatch = mockito.spy(cloudwatch);
+      metrics = new CloudWatchMetricsBackend(cloudwatch, 'DBInstanceIdentifier', 'nfl2015', 60, ['Maximum']);
+   });
 
-    it("should get CPU metrics", async () => {
-        mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
-        .thenCall((params, callback) => {
+   it("should get CPU metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
             callback(null, {
-                Label: dummyCPU.Label,
-                Datapoints: dummyCPU.Datapoints,
+               Label: dummyCPU.Label,
+               Datapoints: dummyCPU.Datapoints,
             } as CloudWatch.GetMetricStatisticsOutput);
-        });
+         });
 
-        await metrics.getMetricsForType(CPUMetric, new Date(), new Date())
+      await metrics.getMetricsForType(CPUMetric, new Date(), new Date())
          .then((cpuMetrics) => {
             expect(cpuMetrics.label).to.equal(dummyCPU.Label);
             expect(cpuMetrics.dataPoints).to.deep.equal(dummyCPU.Datapoints);
          });
 
-    });
+   });
 
-    it("should get read IO metrics", async () => {
-        mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
-        .thenCall((params, callback) => {
+   it("should get read IO metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
             callback(null, {
-                Label: dummyRead.Label,
-                Datapoints: dummyRead.Datapoints,
+               Label: dummyRead.Label,
+               Datapoints: dummyRead.Datapoints,
             } as CloudWatch.GetMetricStatisticsOutput);
-        });
+         });
 
-        await metrics.getMetricsForType(ReadMetric, new Date(), new Date())
+      await metrics.getMetricsForType(ReadMetric, new Date(), new Date())
          .then((readMetrics) => {
             expect(readMetrics.label).to.equal(dummyRead.Label);
             expect(readMetrics.dataPoints).to.deep.equal(dummyRead.Datapoints);
          });
 
-    });
+   });
 
-    it("should get write IO metrics", async () => {
-        mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
-        .thenCall((params, callback) => {
+   it("should get write IO metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
             callback(null, {
-                Label: dummyWrite.Label,
-                Datapoints: dummyWrite.Datapoints,
+               Label: dummyWrite.Label,
+               Datapoints: dummyWrite.Datapoints,
             } as CloudWatch.GetMetricStatisticsOutput);
-        });
+         });
 
-        await metrics.getMetricsForType(WriteMetric, new Date(), new Date())
+      await metrics.getMetricsForType(WriteMetric, new Date(), new Date())
          .then((writeMetrics) => {
             expect(writeMetrics.label).to.equal(dummyWrite.Label);
             expect(writeMetrics.dataPoints).to.deep.equal(dummyWrite.Datapoints);
          });
 
-    });
+   });
 
-    it("should get memory metrics", async () => {
-        mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
-            .thenCall((params, callback) => {
-                callback(null, {
-                    Label: dummyMemory.Label,
-                    Datapoints: dummyMemory.Datapoints,
-                } as CloudWatch.GetMetricStatisticsOutput);
-            });
+   it("should get memory metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
+            callback(null, {
+               Label: dummyMemory.Label,
+               Datapoints: dummyMemory.Datapoints,
+            } as CloudWatch.GetMetricStatisticsOutput);
+         });
 
-        await metrics.getMetricsForType(MemoryMetric, new Date(), new Date())
+      await metrics.getMetricsForType(MemoryMetric, new Date(), new Date())
          .then((memoryMetrics) => {
             expect(memoryMetrics.label).to.equal(dummyMemory.Label);
             expect(memoryMetrics.dataPoints).to.deep.equal(dummyMemory.Datapoints);
          });
 
-    });
+   });
 
-    it("should fail to get CPU metrics", async () => {
-        mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
-        .thenCall((params, callback) => {
+   it("should get read throughput metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
+            callback(null, {
+               Label: dummyReadThroughput.Label,
+               Datapoints: dummyReadThroughput.Datapoints,
+            } as CloudWatch.GetMetricStatisticsOutput);
+         });
+
+      await metrics.getMetricsForType(ReadThroughput, new Date(), new Date())
+         .then((readThruMetrics) => {
+            expect(readThruMetrics.label).to.equal(dummyReadThroughput.Label);
+            expect(readThruMetrics.dataPoints).to.deep.equal(dummyReadThroughput.Datapoints);
+         });
+
+   });
+
+   it("should get write throughput metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
+            callback(null, {
+               Label: dummyWriteThroughput.Label,
+               Datapoints: dummyWriteThroughput.Datapoints,
+            } as CloudWatch.GetMetricStatisticsOutput);
+         });
+
+      await metrics.getMetricsForType(WriteThroughput, new Date(), new Date())
+         .then((writeThruMetrics) => {
+            expect(writeThruMetrics.label).to.equal(dummyWriteThroughput.Label);
+            expect(writeThruMetrics.dataPoints).to.deep.equal(dummyWriteThroughput.Datapoints);
+         });
+
+   });
+
+   it("should get free storage metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
+            callback(null, {
+               Label: dummyFreeStorage.Label,
+               Datapoints: dummyFreeStorage.Datapoints,
+            } as CloudWatch.GetMetricStatisticsOutput);
+         });
+
+      await metrics.getMetricsForType(ReadThroughput, new Date(), new Date())
+         .then((storageMetrics) => {
+            expect(storageMetrics.label).to.equal(dummyFreeStorage.Label);
+            expect(storageMetrics.dataPoints).to.deep.equal(dummyFreeStorage.Datapoints);
+         });
+
+   });
+
+   it("should fail to get CPU metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
             callback("cpu metrics do not exist", null);
-        });
+         });
 
-        const cpuMetrics = await metrics.getMetricsForType(CPUMetric, new Date(), new Date())
+      const cpuMetrics = await metrics.getMetricsForType(CPUMetric, new Date(), new Date())
          .catch((reason) => {
             expect(reason).to.not.be.null;
          });
-    });
+   });
 
-    it("should fail to get read IO metrics", async () => {
-        mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
-        .thenCall((params, callback) => {
+   it("should fail to get read IO metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
             callback("read (io) metrics do not exist", null);
-        });
+         });
 
-        const readMetrics = await metrics.getMetricsForType(ReadMetric, new Date(), new Date())
+      const readMetrics = await metrics.getMetricsForType(ReadMetric, new Date(), new Date())
          .catch((reason) => {
             expect(reason).to.not.be.null;
          });
-    });
+   });
 
-    it("should fail to get write IO metrics", async () => {
-        mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
-        .thenCall((params, callback) => {
+   it("should fail to get write IO metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
             callback("write (io) metrics do not exist", null);
-        });
+         });
 
-        const writeMetrics = await metrics.getMetricsForType(WriteMetric, new Date(), new Date())
+      const writeMetrics = await metrics.getMetricsForType(WriteMetric, new Date(), new Date())
          .catch((reason) => {
             expect(reason).to.not.be.null;
          });
-    });
+   });
 
-    it("should fail to get memory metrics", async () => {
-        mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
-        .thenCall((params, callback) => {
+   it("should fail to get memory metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
             callback("memory metrics do not exist", null);
-        });
+         });
 
-        const memoryMetrics = await metrics.getMetricsForType(MemoryMetric, new Date(), new Date())
+      const memoryMetrics = await metrics.getMetricsForType(MemoryMetric, new Date(), new Date())
          .catch((reason) => {
             expect(reason).to.not.be.null;
          });
-    });
+   });
+
+   it("should fail to get read throughput metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
+            callback("read throughput metrics do not exist", null);
+         });
+
+      const readThruputMetrics = await metrics.getMetricsForType(ReadThroughput, new Date(), new Date())
+         .catch((reason) => {
+            expect(reason).to.not.be.null;
+         });
+   });
+
+   it("should fail to get write throughput metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
+            callback("write throughput metrics do not exist", null);
+         });
+
+      const writeThruputMetrics = await metrics.getMetricsForType(WriteThroughput, new Date(), new Date())
+         .catch((reason) => {
+            expect(reason).to.not.be.null;
+         });
+   });
+
+   it("should fail to get free storage metrics", async () => {
+      mockito.when(spiedCloudwatch.getMetricStatistics(mockito.anything(), mockito.anyFunction()))
+         .thenCall((params, callback) => {
+            callback("free storage metrics do not exist", null);
+         });
+
+      const freeStorageMetrics = await metrics.getMetricsForType(FreeStorage, new Date(), new Date())
+         .catch((reason) => {
+            expect(reason).to.not.be.null;
+         });
+   });
 
 });

--- a/service/src/request-schema/common-schema.ts
+++ b/service/src/request-schema/common-schema.ts
@@ -9,7 +9,9 @@ export const value = {
    nameString: joi.string().regex(/^[a-zA-Z0-9 :_\-]{4,}$/),
 
    /** A string that, when converted to uppercase, matches a MetricType value */
-   metricType: joi.string().regex(/^(?:cpu|read|write|memory)?$/i).uppercase(),
+   metricType: joi.string()
+   .regex(/^(?:cpu utilization|read iops|write iops|freeable memory|read throughput|write throughput|free storage)?$/i)
+   .uppercase(),
 
    /** A string that can be used as an access key */
    // TODO: verify this pattern

--- a/service/src/test/request-schema/common-schema.test.ts
+++ b/service/src/test/request-schema/common-schema.test.ts
@@ -39,22 +39,22 @@ describe("idParams", () => {
 describe("metricTypeQuery", () => {
 
    it("should find the correct type", () => {
-      const cpu = {type: 'cpu'};
+      const cpu = {type: 'CPU Utilization'};
       let result = joi.validate(cpu, metricTypeQuery);
       expect(result.error).to.be.null;
       expect(result.value.type).to.equal(data.MetricType.CPU);
 
-      const read = {type: 'read'};
+      const read = {type: 'Read IOPS'};
       result = joi.validate(read, metricTypeQuery);
       expect(result.error).to.be.null;
       expect(result.value.type).to.equal(data.MetricType.READ);
 
-      const write = {type: 'write'};
+      const write = {type: 'Write IOPS'};
       result = joi.validate(write, metricTypeQuery);
       expect(result.error).to.be.null;
       expect(result.value.type).to.equal(data.MetricType.WRITE);
 
-      const memory = {type: 'memORY'};
+      const memory = {type: 'Freeable Memory'};
       result = joi.validate(memory, metricTypeQuery);
       expect(result.error).to.be.null;
       expect(result.value.type).to.equal(data.MetricType.MEMORY);


### PR DESCRIPTION
- Refactored sendMetricsToS3 methods to loop through all metrics instead of only handling 4 metric types 
- Add support for storage and throughput metrics from cloudwatch
- Write new tests for new supported metrics