### PR TITLE
Environment Invite (Backend)

### DIFF
--- a/common/src/dao/environment-dao.ts
+++ b/common/src/dao/environment-dao.ts
@@ -41,7 +41,7 @@ export class EnvironmentDao extends Dao {
    }
 
    public async getEnvironmentFull(id: number): Promise<data.IEnvironmentFull | null> {
-      const queryStr = 'SELECT e.name AS envName, e.ownerId AS ownerId, d.name AS dbName, host, ' +
+      const queryStr = 'SELECT e.id, e.name AS envName, e.ownerId AS ownerId, d.name AS dbName, host, ' +
          'user, pass, instance, ' +
          'parameterGroup, bucket, accessKey, secretKey, region ' +
          'FROM Environment AS e JOIN DBReference AS d ON e.dbId = d.id ' +
@@ -135,6 +135,7 @@ export class EnvironmentDao extends Dao {
       return {
          id: row.id,
          name: row.name,
+         ownerId: row.ownerId,
          iamId: row.iamId,
          dbId: row.dbId,
          s3Id: row.s3Id,

--- a/common/src/dao/environment-invite-dao.ts
+++ b/common/src/dao/environment-invite-dao.ts
@@ -60,29 +60,39 @@ export class EnvironmentInviteDao extends Dao {
          Promise<IEnvironmentMember[] | null> {
 
       // TODO
-      // get a list of all users who are either the nvironment owner
-      // or have accepted an invite to the environment.
 
-      throw new Error("NOT IMPLEMENTED");
-
-      // return null;
+      return null;
    }
 
    public async getUserMembership(user: IUser, environment: IEnvironment):
          Promise<IEnvironmentMember> {
 
-      // TODO
-      // determine whether or not a user belongs to an environment and if they have the
-      // correct admin privileges
+      let isMember = false;
+      let isAdmin = false;
 
-      throw new Error("NOT IMPLEMENTED");
+      // If the user created the environment
+      if (environment.ownerId === user.id) {
+         isMember = true;
+         isAdmin = true;
 
-      // return {
-      //    userId: user.id!,
-      //    email: user.email!,
-      //    isMember: false,
-      //    isAdmin: false,
-      // };
+      } else {
+         // otherwise, they were added through invite
+         const query = 'SELECT userId, isAdmin FROM EnvironmentUser WHERE userId = ? '
+            + 'AND environmentId = ? AND accepted = 1';
+         const rows = await this.query<any[]>(query, [user.id]);
+         if (rows.length > 0) {
+            isMember = true;
+            isAdmin = !!(rows[0].isAdmin);
+         }
+      }
+
+      return {
+         userId: user.id!,
+         email: user.email!,
+         isMember,
+         isAdmin,
+      };
+
    }
 
    private rowToInvite(row: any) {

--- a/common/src/dao/environment-invite-dao.ts
+++ b/common/src/dao/environment-invite-dao.ts
@@ -1,0 +1,96 @@
+import * as crypto from 'crypto';
+
+import { IEnvironment, IEnvironmentUser as Invite, IUser } from '../data';
+import { defaultLogger } from '../logging';
+import { ConnectionPool } from './cnnPool';
+import { Dao } from './dao';
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+export interface IEnvironmentMember {
+   userId: number;
+   email: string;
+   isMember: boolean;
+   isAdmin: boolean;
+}
+
+export class EnvironmentInviteDao extends Dao {
+
+   public async getInvite(id: number): Promise<Invite | null> {
+      const rows = await this.query<any[]>('SELECT * FROM EnvironmentUser WHERE id = ?', [id]);
+      if (rows.length < 1) {
+         return null;
+      }
+      return this.rowToInvite(rows[0]);
+   }
+
+   public async getInviteByCode(code: string): Promise<Invite | null> {
+      const rows = await this.query<any[]>('SELECT * from EnvironmentUser WHERE inviteCode = ?',
+         [code]);
+      if (rows.length < 1) {
+         return null;
+      }
+      return this.rowToInvite(rows[0]);
+   }
+
+   public async inviteUser(environment: IEnvironment, user: IUser): Promise<Invite | null> {
+      const inviteCode = crypto.randomBytes(4).toString('hex');
+      const invite: Invite = {
+         environmentId: environment.id,
+         userId: user.id,
+         isAdmin: false, // for now, might use later
+         inviteCode,
+         accepted: false, // set to true by the user
+         createdAt: new Date().getTime(),
+      };
+      const result = await this.query<any>('INSERT INTO EnvironmentUser SET ?', [invite]);
+      return await this.getInvite(result.insertId);
+   }
+
+   public async acceptInvite(invite: Invite) {
+      const now = new Date().getTime();
+      if (now - invite.createdAt! > MS_PER_DAY) {
+         throw new Error("This invite has expired");
+      }
+      await this.query('UPDATE EnvironmentUser SET accepted = 1 WHERE id = ?', [invite.id]);
+      return;
+   }
+
+   public async getUserMemberships(environment: IEnvironment):
+         Promise<IEnvironmentMember[] | null> {
+
+      // TODO
+      // get a list of all users who are either the nvironment owner
+      // or have accepted an invite to the environment.
+
+      throw new Error("NOT IMPLEMENTED");
+
+      // return null;
+   }
+
+   public async getUserMembership(user: IUser, environment: IEnvironment):
+         Promise<IEnvironmentMember> {
+
+      // TODO
+      // determine whether or not a user belongs to an environment and if they have the
+      // correct admin privileges
+
+      throw new Error("NOT IMPLEMENTED");
+
+      // return {
+      //    userId: user.id!,
+      //    email: user.email!,
+      //    isMember: false,
+      //    isAdmin: false,
+      // };
+   }
+
+   private rowToInvite(row: any) {
+      return {
+         ...row,
+         isAdmin: !!row.isAdmin,
+         accepted: !!row.accepted,
+      };
+   }
+
+}

--- a/common/src/dao/user-dao.ts
+++ b/common/src/dao/user-dao.ts
@@ -1,4 +1,4 @@
-import { IEnvironmentUser, IUser } from '../data';
+import { IUser } from '../data';
 import { defaultLogger } from '../logging';
 import { Dao } from './dao';
 

--- a/common/src/data.ts
+++ b/common/src/data.ts
@@ -16,6 +16,9 @@ export interface IEnvironmentUser {
    environmentId?: number;
    userId?: number;
    isAdmin?: boolean;
+   inviteCode?: string;
+   accepted?: boolean;
+   createdAt?: number;
 }
 
 export enum ChildProgramType { CAPTURE = 'CAPTURE', REPLAY = 'REPLAY' }

--- a/common/src/main.ts
+++ b/common/src/main.ts
@@ -36,6 +36,7 @@ export * from './dao/cnnPool';
 export * from './dao/config';
 export * from './dao/dao';
 export * from './dao/environment-dao';
+export * from './dao/environment-invite-dao';
 export * from './dao/replay-dao';
 export * from './dao/session-dao';
 export * from './dao/user-dao';

--- a/scripts/db/mycrt.sql
+++ b/scripts/db/mycrt.sql
@@ -9,7 +9,7 @@ CREATE TABLE User (
    isAdmin TINYINT(1) DEFAULT 0,
 
    -- Session Stuff
-   sessionToken VARCHAR(256) DEFAULT NULL,
+   sessionToken VARCHAR(32) DEFAULT NULL,
    loginTime BIGINT(11) DEFAULT NULL,
    lastTokenCheck BIGINT(11) DEFAULT NULL,
 
@@ -32,9 +32,12 @@ CREATE TABLE Environment (
 
 CREATE TABLE EnvironmentUser (
    id INT(11) AUTO_INCREMENT PRIMARY KEY,
-   environmentId INT(11) REFERENCES Environment(id),
-   userId INT(11) REFERENCES User(id),
+   environmentId INT(11) NOT NULL REFERENCES Environment(id),
+   userId INT(11) NOT NULL REFERENCES User(id),
    isAdmin TINYINT(1) DEFAULT 0,
+   inviteCode VARCHAR(8) NOT NULL,
+   accepted TINYINT(1) DEFAULT 0,
+   createdAt BIGINT(11) NOT NULL,
    CONSTRAINT environmentIdKey
       FOREIGN KEY (environmentId)
       REFERENCES Environment(id)

--- a/service/src/auth/session.ts
+++ b/service/src/auth/session.ts
@@ -27,7 +27,7 @@ export async function createActiveSession(user: IUser, response?: Response): Pro
    }
 
    logger.info(`Creating new session for user ${user.id}`);
-   const newToken = crypto.randomBytes(32).toString('hex');
+   const newToken = crypto.randomBytes(16).toString('hex');
    logger.info(`  ${sessionTokenName}: ${newToken}`);
 
    await sessionDao.beginSession(user, newToken);

--- a/service/src/dao/mycrt-dao.ts
+++ b/service/src/dao/mycrt-dao.ts
@@ -1,10 +1,11 @@
-import { CaptureDao, ConnectionPool, EnvironmentDao, mycrtDbConfig, ReplayDao,
+import { CaptureDao, ConnectionPool, EnvironmentDao, EnvironmentInviteDao, mycrtDbConfig, ReplayDao,
    SessionDao, UserDao } from '@lbt-mycrt/common';
 
 const pool = new ConnectionPool(mycrtDbConfig);
 
 export const captureDao: CaptureDao = new CaptureDao(pool);
 export const environmentDao: EnvironmentDao = new EnvironmentDao(pool);
+export const environmentInviteDao: EnvironmentInviteDao = new EnvironmentInviteDao(pool);
 export const replayDao: ReplayDao = new ReplayDao(pool);
 export const sessionDao: SessionDao = new SessionDao(pool);
 export const userDao: UserDao = new UserDao(pool);

--- a/service/src/request-schema/environment-invite-schema.ts
+++ b/service/src/request-schema/environment-invite-schema.ts
@@ -1,0 +1,12 @@
+import * as joi from 'joi';
+
+import { value } from './common-schema';
+
+export const inviteBody: joi.ObjectSchema = joi.object().keys({
+   environmentId: value.id.required(),
+   userEmail: value.email.required(),
+});
+
+export const acceptBody: joi.ObjectSchema = joi.object().keys({
+   inviteCode: joi.string().regex(/[a-f0-9]{8}/i).required(),
+});

--- a/service/src/routes/environment-invite.ts
+++ b/service/src/routes/environment-invite.ts
@@ -25,9 +25,10 @@ export default class EnvironmentInviteRouter extends SelfAwareRouter {
 
       this.router.post('/',
          check.validBody(schema.inviteBody),
-         async (request, response) => {
+         this.handleHttpErrors(async (request, response) => {
 
             // find the environment
+            logger.info("Getting the environment");
             const environmentId = request.body.environmentId;
             const environment = await environmentDao.getEnvironment(environmentId);
             if (!environment) {
@@ -35,6 +36,7 @@ export default class EnvironmentInviteRouter extends SelfAwareRouter {
             }
 
             // user must be an administrator
+            logger.info("Checking if user can invite others");
             const membership = await inviteDao.getUserMembership(request.user!, environment);
             if (!membership.isMember) {
                throw new HttpError(http.NOT_FOUND, `Environment ${environmentId} does not exist`);
@@ -42,35 +44,56 @@ export default class EnvironmentInviteRouter extends SelfAwareRouter {
                throw new HttpError(http.FORBIDDEN, `Only environment administrators can invite`);
             }
 
+            // find the user to invite
+            logger.info("Getting the user to invite");
+            const user = await userDao.getUser(request.body.userEmail);
+            if (!user) {
+               throw new HttpError(http.BAD_REQUEST,
+                  `User ${request.body.userEmail} does not exist`);
+            }
+
             // good to go!
-            const invite = await inviteDao.inviteUser(environment, request.user!);
+            logger.info("Creating invite");
+            const invite = await inviteDao.inviteUser(environment, user);
+
+            logger.info("Invite created!");
             response.json(invite);
          },
-      );
+      ));
 
       this.router.put('/accept',
          check.validBody(schema.acceptBody),
-         async (request, response) => {
+         this.handleHttpErrors(async (request, response) => {
 
             // get the invitation
+            logger.info("Getting the invitation");
             const invite = await inviteDao.getInviteByCode(request.body.inviteCode);
 
             // make sure it exists and belongs to the user
+            logger.info(`Making sure it belongs to ${request.user!.email}`);
             if (!invite || invite.userId !== request.user!.id) {
                throw new HttpError(http.NOT_FOUND);
             }
 
+            // check if it has already been accepted
+            logger.info("Checking if the invite has already been accepted");
+            if (invite.accepted) {
+               throw new HttpError(http.CONFLICT, "Invite has already been accepted");
+            }
+
             // accept it!
+            logger.info("Accepting invitation");
             try {
                await inviteDao.acceptInvite(invite);
             } catch (e) {
                throw new HttpError(http.CONFLICT, "Invitation has expired");
             }
 
-            response.status(http.OK);
+            logger.info("Done");
+            response.status(http.OK).end();
 
          },
-      );
+      ));
 
    }
 

--- a/service/src/routes/environment-invite.ts
+++ b/service/src/routes/environment-invite.ts
@@ -1,0 +1,77 @@
+import * as http from 'http-status-codes';
+
+import { Logging, ServerIpcNode } from '@lbt-mycrt/common';
+
+import * as session from '../auth/session';
+import { environmentDao, environmentInviteDao as inviteDao, userDao } from '../dao/mycrt-dao';
+import { HttpError } from '../http-error';
+import * as check from '../middleware/request-validation';
+import * as schema from '../request-schema/environment-invite-schema';
+import SelfAwareRouter from './self-aware-router';
+
+const logger = Logging.defaultLogger(__dirname);
+
+export default class EnvironmentInviteRouter extends SelfAwareRouter {
+   public name: string = 'environmentInvite';
+   public urlPrefix: string = '/invites';
+
+   constructor(ipcNode: ServerIpcNode) {
+      super(ipcNode, [
+         session.loggedInOrForbidden,
+      ]);
+   }
+
+   protected mountRoutes(): void {
+
+      this.router.post('/',
+         check.validBody(schema.inviteBody),
+         async (request, response) => {
+
+            // find the environment
+            const environmentId = request.body.environmentId;
+            const environment = await environmentDao.getEnvironment(environmentId);
+            if (!environment) {
+               throw new HttpError(http.NOT_FOUND, `Environment ${environmentId} does not exist`);
+            }
+
+            // user must be an administrator
+            const membership = await inviteDao.getUserMembership(request.user!, environment);
+            if (!membership.isMember) {
+               throw new HttpError(http.NOT_FOUND, `Environment ${environmentId} does not exist`);
+            } else if (!membership.isAdmin) {
+               throw new HttpError(http.FORBIDDEN, `Only environment administrators can invite`);
+            }
+
+            // good to go!
+            const invite = await inviteDao.inviteUser(environment, request.user!);
+            response.json(invite);
+         },
+      );
+
+      this.router.put('/accept',
+         check.validBody(schema.acceptBody),
+         async (request, response) => {
+
+            // get the invitation
+            const invite = await inviteDao.getInviteByCode(request.body.inviteCode);
+
+            // make sure it exists and belongs to the user
+            if (!invite || invite.userId !== request.user!.id) {
+               throw new HttpError(http.NOT_FOUND);
+            }
+
+            // accept it!
+            try {
+               await inviteDao.acceptInvite(invite);
+            } catch (e) {
+               throw new HttpError(http.CONFLICT, "Invitation has expired");
+            }
+
+            response.status(http.OK);
+
+         },
+      );
+
+   }
+
+}

--- a/service/src/routes/environment.ts
+++ b/service/src/routes/environment.ts
@@ -6,7 +6,7 @@ import { Logging, ServerIpcNode } from '@lbt-mycrt/common';
 import * as data from '@lbt-mycrt/common/dist/data';
 
 import * as session from '../auth/session';
-import { environmentDao } from '../dao/mycrt-dao';
+import { environmentDao, environmentInviteDao as inviteDao } from '../dao/mycrt-dao';
 import { HttpError } from '../http-error';
 import * as check from '../middleware/request-validation';
 import * as schema from '../request-schema/environment-schema';
@@ -26,32 +26,47 @@ export default class EnvironmentRouter extends SelfAwareRouter {
    protected mountRoutes(): void {
       const logger = Logging.defaultLogger(__dirname);
 
-      this.router.get('/', check.validQuery(schema.envNameQuery),
+      this.router.get('/',
+         check.validQuery(schema.envNameQuery),
          this.handleHttpErrors(async (request, response) => {
 
-         const envName = request.query.name;
-         let environments;
-         if (envName) {
-            environments = await environmentDao.getEnvironmentByName(envName, request.user);
-         } else {
-            environments = await environmentDao.getAllEnvironments(request.user);
-         }
+            const envName = request.query.name;
+            let environments;
+            if (envName) {
+               const env = await environmentDao.getEnvironmentByName(envName);
+               if (!env) {
+                  throw new HttpError(http.NOT_FOUND);
+               }
+               const membership = await inviteDao.getUserMembership(request.user!, env);
+               if (!membership.isMember) {
+                  throw new HttpError(http.NOT_FOUND);
+               }
+               environments = [env];
+            } else {
+               environments = await inviteDao.getAllEnvironmentsWithMembership(request.user!);
+            }
 
-         response.json(environments);
-      }));
+            response.json(environments);
+         },
+      ));
 
       this.router.get('/:id(\\d+)', check.validParams(schema.idParams),
             this.handleHttpErrors(async (request, response) => {
 
          const id = request.params.id;
+         logger.info(`Getting environment ${id}`);
          const environment = await environmentDao.getEnvironmentFull(id);
          if (!environment) {
             throw new HttpError(http.NOT_FOUND);
          }
-         if (environment.ownerId !== request.user!.id) {
-            logger.info(`owner = ${environment!.ownerId}, user = ${request.user!.id}`);
+
+         logger.info(`Getting membership for user ${request.user!.id}`);
+         const membership = await inviteDao.getUserMembership(request.user!, environment);
+         if (!membership.isMember) {
+            logger.info(`User ${request.user!.id} is not a member of this environment`);
             throw new HttpError(http.NOT_FOUND);
          }
+
          response.json(environment);
 
       }));

--- a/service/src/routes/environment.ts
+++ b/service/src/routes/environment.ts
@@ -10,6 +10,7 @@ import { environmentDao } from '../dao/mycrt-dao';
 import { HttpError } from '../http-error';
 import * as check from '../middleware/request-validation';
 import * as schema from '../request-schema/environment-schema';
+import InviteRouter from './environment-invite';
 import SelfAwareRouter from './self-aware-router';
 
 export default class EnvironmentRouter extends SelfAwareRouter {
@@ -141,5 +142,9 @@ export default class EnvironmentRouter extends SelfAwareRouter {
          response.json(environment);
 
       }));
+
+      // invites
+      const inviteRouter = new InviteRouter(this.ipcNode);
+      this.router.use(inviteRouter.urlPrefix, inviteRouter.router);
    }
 }

--- a/service/src/routes/index-redirect.ts
+++ b/service/src/routes/index-redirect.ts
@@ -4,13 +4,13 @@ import * as http from 'http-status-codes';
 import { Logging } from '@lbt-mycrt/common';
 import { Pages } from '@lbt-mycrt/gui';
 
-import { environmentDao } from '../dao/mycrt-dao';
+import { environmentInviteDao as inviteDao } from '../dao/mycrt-dao';
 
 const logger = Logging.defaultLogger(__dirname);
 
 export const indexRouteHandler = async (request: Request, response: Response) => {
 
-   const environments = await environmentDao.getAllEnvironments();
+   const environments = await inviteDao.getAllEnvironmentsWithMembership(request.user!);
    const doRedirect = environments.length > 0;
 
    if (doRedirect) {

--- a/service/src/test/routes/environment.test.ts
+++ b/service/src/test/routes/environment.test.ts
@@ -29,8 +29,8 @@ export const environmentTests = (mycrt: MyCrtServiceTestClient) => function() {
    });
 
    it("should get all environments", async function() {
-      const responsePost1 = await mycrt.post(http.OK, '/api/environments/', newEnvBody);
-      const responsePost2 = await mycrt.post(http.OK, '/api/environments/', newEnvBody2);
+      const responsePost1 = await mycrt.post(http.OK, '/api/environments', newEnvBody);
+      const responsePost2 = await mycrt.post(http.OK, '/api/environments', newEnvBody2);
       const response = await mycrt.get(http.OK, '/api/environments');
       expect(response.body.length).to.equal(2);
    });


### PR DESCRIPTION
Added support through the API for users to invite other (which generates an invitation code) to their environments. The other user then needs to accept the invite.

## Sending an Invitation

```
---------------
POST to /api/environments/invites
{
  "environmentId": 1,
  "userEmail": "lilbobby@tables.com"
}
---------------
Response:
{
    "id": 4,
    "environmentId": 1,
    "userId": 2,
    "isAdmin": false,
    "inviteCode": "c1047891",
    "accepted": false,
    "createdAt": 1525108389155
}
---------------
```

## Accepting an Invitation

```
---------------
PUT to /api/environments/invites/accept
{
  "inviteCode": "c1047891"
}
---------------
Response: 200
---------------
```