### PR TITLE
[LIL-189] Add Optional S3 Prefix to Environments

### DIFF
--- a/capture/src/capture.ts
+++ b/capture/src/capture.ts
@@ -58,6 +58,7 @@ export class Capture extends Subprocess implements ICaptureIpcNodeDelegate {
          type: ChildProgramType.CAPTURE,
          status: this.status,
          start: this.startTime || undefined,
+         envId: this.env.id,
       };
    }
 

--- a/capture/src/main.ts
+++ b/capture/src/main.ts
@@ -66,7 +66,7 @@ async function runCapture(): Promise<void> {
       };
 
       const buildMockCapture = (): Capture => {
-         const storage = new LocalBackend(getSandboxPath());
+         const storage = new LocalBackend(getSandboxPath(), env.prefix);
          const metrics = new MockMetricsBackend(5);
          const workloadLogger = new LocalWorkloadLogger(ChildProgramType.CAPTURE, config.id, storage, env);
          return new Capture(config, workloadLogger, storage, metrics, env);

--- a/capture/src/main.ts
+++ b/capture/src/main.ts
@@ -57,7 +57,7 @@ async function runCapture(): Promise<void> {
    if (env) {
       const buildCapture = (): Capture => {
          const awsConfig = {region: env.region, accessKeyId: env.accessKey, secretAccessKey: env.secretKey};
-         const storage = new S3Backend(new S3(awsConfig), env.bucket);
+         const storage = new S3Backend(new S3(awsConfig), env.bucket, env.prefix);
          const metrics = new CloudWatchMetricsBackend(new CloudWatch(awsConfig), DBIdentifier, env.instance, period,
             statistics);
          const workloadLogger: WorkloadLogger = new AwsWorkloadLogger(ChildProgramType.CAPTURE, config.id,

--- a/common/src/dao/environment-dao.ts
+++ b/common/src/dao/environment-dao.ts
@@ -43,7 +43,7 @@ export class EnvironmentDao extends Dao {
    public async getEnvironmentFull(id: number): Promise<data.IEnvironmentFull | null> {
       const queryStr = 'SELECT e.name AS envName, e.ownerId AS ownerId, d.name AS dbName, host, ' +
          'user, pass, instance, ' +
-         'parameterGroup, bucket, accessKey, secretKey, region ' +
+         'parameterGroup, bucket, prefix, accessKey, secretKey, region ' +
          'FROM Environment AS e JOIN DBReference AS d ON e.dbId = d.id ' +
          'JOIN S3Reference AS s ON e.S3Id = s.id JOIN IAMReference AS i ON e.iamId = i.id ' +
          'WHERE e.id = ?';
@@ -156,6 +156,7 @@ export class EnvironmentDao extends Dao {
          instance: row.instance,
          parameterGroup: row.parameterGroup,
          bucket: row.bucket,
+         prefix: row.prefix,
       };
    }
 
@@ -184,6 +185,7 @@ export class EnvironmentDao extends Dao {
       return {
          id: row.id,
          bucket: row.bucket,
+         prefix: row.prefix,
       };
    }
 

--- a/common/src/data.ts
+++ b/common/src/data.ts
@@ -91,6 +91,7 @@ export interface IEnvironmentFull {
    instance: string;
    parameterGroup: string;
    bucket: string;
+   prefix: string;
 }
 
 /** IAM Profile */
@@ -116,6 +117,7 @@ export interface IDbReference {
 export interface IS3Reference {
    id?: number;
    bucket?: string;
+   prefix?: string;
 }
 
 /** Commands in a Workload */

--- a/common/src/data.ts
+++ b/common/src/data.ts
@@ -57,6 +57,7 @@ export interface IReplay extends IChildProgram {
    type: ChildProgramType.REPLAY;
    captureId?: number;
    dbId?: number;
+   envId?: number;
 }
 
 export interface IReplayFull extends IChildProgram {

--- a/common/src/metrics/mock-metrics-backend.ts
+++ b/common/src/metrics/mock-metrics-backend.ts
@@ -25,6 +25,12 @@ export class MockMetricsBackend extends MetricsBackend {
             return this.makeMockData(metric, 510000000, 540000000, startTime, endTime);
          case MetricType.MEMORY:
             return this.makeMockData(metric, 0, 0.003, startTime, endTime);
+         case MetricType.READTHROUGHPUT:
+            return this.makeMockData(metric, 510000000, 540000000, startTime, endTime);
+         case MetricType.WRITETHROUGHPUT:
+            return this.makeMockData(metric, 510000000, 540000000, startTime, endTime);
+         case MetricType.FREESTORAGE:
+            return this.makeMockData(metric, 510000000, 540000000, startTime, endTime);
          default:
             throw new Error(`Unknown metricName: ${metric.metricType}`);
       }

--- a/common/src/storage/backend-schema.ts
+++ b/common/src/storage/backend-schema.ts
@@ -13,7 +13,7 @@ const childProcessTypeToString = (type?: ChildProgramType): string => {
  */
 const getRootPrefix = (childProgram: IChildProgram): string => {
    const logger = defaultLogger(__dirname);
-   logger.info(`child program for root prefix is: ${childProgram}`);
+   logger.info(`child program env id for root prefix is: ${childProgram.envId}`);
    return `environment${childProgram.envId}/${childProcessTypeToString(childProgram.type)}${childProgram.id}/`;
 };
 

--- a/common/src/storage/backend-schema.ts
+++ b/common/src/storage/backend-schema.ts
@@ -1,4 +1,5 @@
 import { ChildProgramType, IChildProgram } from '../data';
+import { defaultLogger } from '../logging';
 
 const childProcessTypeToString = (type?: ChildProgramType): string => {
    if (!type) {
@@ -11,7 +12,9 @@ const childProcessTypeToString = (type?: ChildProgramType): string => {
  * Get the root prefix for a child program.
  */
 const getRootPrefix = (childProgram: IChildProgram): string => {
-   return `${childProcessTypeToString(childProgram.type)}${childProgram.id}/`;
+   const logger = defaultLogger(__dirname);
+   logger.info(`child program for root prefix is: ${childProgram}`);
+   return `environment${childProgram.envId}/${childProcessTypeToString(childProgram.type)}${childProgram.id}/`;
 };
 
 /**

--- a/common/src/storage/local-backend.ts
+++ b/common/src/storage/local-backend.ts
@@ -62,12 +62,13 @@ export class LocalBackend extends StorageBackend {
 
    public async deletePrefix(dirPrefix: string): Promise<void> {
       dirPrefix = path.join(this.rootDir, this.attachPrefix(dirPrefix));
+      logger.info(`deleting prefix: ${dirPrefix}`);
       if (await fs.pathExists(dirPrefix)) {
          await fs.remove(dirPrefix);
       }
    }
 
-   public attachPrefix(key: string): string {
+   private attachPrefix(key: string): string {
       if (key.lastIndexOf(this.prefix, 0) !== 0) {
          key = (this.prefix != null ? this.prefix + "/" + key : key);
       }

--- a/common/src/storage/local-backend.ts
+++ b/common/src/storage/local-backend.ts
@@ -5,10 +5,12 @@ import Logging = require('../logging');
 
 import { StorageBackend } from './backend';
 
+import { DirectoryService } from 'aws-sdk';
+
 const logger = Logging.defaultLogger(__dirname);
 
 export class LocalBackend extends StorageBackend {
-   constructor(private rootDir: string) {
+   constructor(private rootDir: string, private prefix: string) {
       super();
 
       if (!fs.existsSync(this.rootDir)) {
@@ -19,11 +21,12 @@ export class LocalBackend extends StorageBackend {
    public rootDirectory(): string { return this.rootDir; }
 
    public async exists(key: string): Promise<boolean> {
-      const file = path.join(this.rootDir, key);
+      const file = path.join(this.rootDir, this.attachPrefix(key));
       return await fs.pathExists(file);
    }
 
    public async allMatching(dirPrefix: string, pattern: RegExp): Promise<string[]> {
+      dirPrefix = this.attachPrefix(dirPrefix);
       const fullDirPrefix = path.join(this.rootDir, dirPrefix);
       const result: string[] = [];
 
@@ -39,12 +42,12 @@ export class LocalBackend extends StorageBackend {
    }
 
    public async readJson<T>(key: string): Promise<T> {
-      const file = path.join(this.rootDir, key);
+      const file = path.join(this.rootDir, this.attachPrefix(key));
       return fs.readJsonSync(file);
    }
 
    public async writeJson<T>(key: string, value: T): Promise<void> {
-      const file = path.join(this.rootDir, key);
+      const file = path.join(this.rootDir, this.attachPrefix(key));
       const dir = path.dirname(file);
       if (!fs.existsSync(dir)) {
          fs.mkdirsSync(dir);
@@ -53,15 +56,22 @@ export class LocalBackend extends StorageBackend {
    }
 
    public async deleteJson(key: string): Promise<void> {
-      const file = path.join(this.rootDir, key);
+      const file = path.join(this.rootDir, this.attachPrefix(key));
       return await fs.unlink(file);
    }
 
    public async deletePrefix(dirPrefix: string): Promise<void> {
-      dirPrefix = path.join(this.rootDir, dirPrefix);
+      dirPrefix = path.join(this.rootDir, this.attachPrefix(dirPrefix));
       if (await fs.pathExists(dirPrefix)) {
          await fs.remove(dirPrefix);
       }
+   }
+
+   public attachPrefix(key: string): string {
+      if (key.lastIndexOf(this.prefix, 0) !== 0) {
+         key = (this.prefix != null ? this.prefix + "/" + key : key);
+      }
+      return key;
    }
 
 }

--- a/common/src/storage/s3-backend.ts
+++ b/common/src/storage/s3-backend.ts
@@ -7,7 +7,7 @@ import { StorageBackend } from './backend';
 const logger = Logging.defaultLogger(__dirname);
 
 export class S3Backend extends StorageBackend {
-   constructor(private s3: S3, private bucket: string) {
+   constructor(private s3: S3, private bucket: string, private prefix: string) {
       super();
    }
 

--- a/common/src/storage/s3-backend.ts
+++ b/common/src/storage/s3-backend.ts
@@ -36,7 +36,6 @@ export class S3Backend extends StorageBackend {
    public async allMatching(dirPrefix: string, pattern: RegExp): Promise<string[]> {
       dirPrefix = this.attachPrefix(dirPrefix);
       const keys = await this.listObjects(dirPrefix);
-      logger.info(`in allMatching and keys returned are ${keys}`);
       const result: string[] = [];
       keys.forEach((key) => {
          const check = key.substring(dirPrefix.length);
@@ -113,7 +112,9 @@ export class S3Backend extends StorageBackend {
    }
 
    public async deletePrefix(dirPrefix: string): Promise<void> {
-      const keys = await this.listObjects(this.attachPrefix(dirPrefix));
+      dirPrefix = this.attachPrefix(dirPrefix);
+      logger.info(`deleting prefix: ${dirPrefix}`);
+      const keys = await this.listObjects(dirPrefix);
       keys.forEach(async (key) => await this.deleteJson(key));
    }
 

--- a/common/src/test/metrics/metrics-backend.test.ts
+++ b/common/src/test/metrics/metrics-backend.test.ts
@@ -17,6 +17,7 @@ describe("MetricsBackend", () => {
       status: ChildProgramStatus.DONE,
       start: new Date(),
       end: new Date(),
+      envId: 0,
    };
 
    const c2: IChildProgram = {
@@ -26,6 +27,7 @@ describe("MetricsBackend", () => {
       status: ChildProgramStatus.DONE,
       start: new Date(),
       end: new Date(),
+      envId: 0,
    };
 
    const dummyMetrics: IMetricsList[] = [

--- a/common/src/test/storage/backend-schema.test.ts
+++ b/common/src/test/storage/backend-schema.test.ts
@@ -13,35 +13,36 @@ describe("backend-schema", () => {
    const capture: data.ICapture = {
       type: data.ChildProgramType.CAPTURE,
       id: 100,
+      envId: 100,
    };
 
    it("should get the root prefix", () => {
       const actual = path.getRootPrefix(capture);
-      const expected = "capture100/";
+      const expected = "environment100/capture100/";
       expect(actual).to.equal(expected);
    });
 
    it("should get the depot prefix", () => {
       const actual = path.getDepotPrefix(capture);
-      const expected = "capture100/depot/";
+      const expected = "environment100/capture100/depot/";
       expect(actual).to.equal(expected);
    });
 
    it("should get the done metrics key", () => {
       const actual = path.metrics.getDoneKey(capture);
-      const expected = "capture100/metrics.json";
+      const expected = "environment100/capture100/metrics.json";
       expect(actual).to.equal(expected);
    });
 
    it("should get an in-progress metrics key", () => {
       const actual = path.metrics.getInProgressKey(capture, date);
-      const expected = "capture100/metrics-100200300.json";
+      const expected = "environment100/capture100/metrics-100200300.json";
       expect(actual).to.equal(expected);
    });
 
    it("should get a single sample metrics key", () => {
       const actual = path.metrics.getSingleSampleKey(capture, date);
-      const expected = "capture100/depot/metrics-100200300.json";
+      const expected = "environment100/capture100/depot/metrics-100200300.json";
       expect(actual).to.equal(expected);
    });
 

--- a/common/src/test/storage/local-backend.test.ts
+++ b/common/src/test/storage/local-backend.test.ts
@@ -16,7 +16,7 @@ describe("LocalBackend", () => {
    before(() => {
       rootDir = path.join(__dirname, uuid());
       fs.mkdirSync(rootDir);
-      backend = new LocalBackend(rootDir);
+      backend = new LocalBackend(rootDir, "");
    });
 
    after(() => {

--- a/common/src/test/storage/s3-backend.test.ts
+++ b/common/src/test/storage/s3-backend.test.ts
@@ -34,7 +34,7 @@ describe("S3Backend", () => {
             callback();
          });
 
-      backend = new S3Backend(s3, 'lil-test-environment');
+      backend = new S3Backend(s3, 'lil-test-environment', 'lil-prefix');
    });
 
    it("should know if a file exists", async () => {

--- a/gui/src/pages/capture.tsx
+++ b/gui/src/pages/capture.tsx
@@ -122,7 +122,7 @@ class CaptureApp extends React.Component<any, any> {
    }
 
    public async deleteReplay(id: number, deleteLogs: boolean) {
-      await mycrt.deleteReplay(id);
+      await mycrt.deleteReplay(id, deleteLogs);
       window.location.assign(`./capture?id=${this.state.captureId}&envId=${this.state.envId}&view=replays`);
    }
 

--- a/gui/src/pages/capture.tsx
+++ b/gui/src/pages/capture.tsx
@@ -283,7 +283,8 @@ class CaptureApp extends React.Component<any, any> {
                   <div className="tab-pane" id="replays" role="tabpanel">
                      {this.state.replayObj ?
                         <ReplayInfo replay={this.state.replayObj} bucket={this.state.env.bucket}
-                        envId={this.state.envId} captureId={this.state.captureId} delete={this.deleteReplay}/> : null
+                        envId={this.state.envId} captureId={this.state.captureId} prefix={this.state.env.prefix}
+                        delete={this.deleteReplay}/> : null
                      }<br/>
                      <div className="page-header">
                         <h2 style={{display: "inline"}}>Replays</h2>

--- a/gui/src/pages/components/capture_info_comp.tsx
+++ b/gui/src/pages/components/capture_info_comp.tsx
@@ -42,7 +42,7 @@ export class CaptureInfo extends React.Component<any, any>  {
                   <div className="col-xs-6" style={{padding: "20px 20px 0px"}}>
                      <h5>S3 File Storage:</h5>
                      <label><b>&nbsp;&nbsp;&nbsp;Bucket: </b>{this.props.env.bucket}</label><br/>
-                     <label><b>&nbsp;&nbsp;&nbsp;Folder: </b>{"capture" + this.props.capture.id}</label><br/><br/>
+                     <label><b>&nbsp;&nbsp;&nbsp;Prefix: </b>{this.props.env.prefix}</label><br/><br/>
                   </div>
                </div>
             </div>

--- a/gui/src/pages/components/capture_info_comp.tsx
+++ b/gui/src/pages/components/capture_info_comp.tsx
@@ -42,7 +42,8 @@ export class CaptureInfo extends React.Component<any, any>  {
                   <div className="col-xs-6" style={{padding: "20px 20px 0px"}}>
                      <h5>S3 File Storage:</h5>
                      <label><b>&nbsp;&nbsp;&nbsp;Bucket: </b>{this.props.env.bucket}</label><br/>
-                     <label><b>&nbsp;&nbsp;&nbsp;Prefix: </b>{this.props.env.prefix}</label><br/><br/>
+                     <label><b>&nbsp;&nbsp;&nbsp;Prefix: </b>{this.props.env.prefix + "/environment" +
+                        this.props.env.id + "/capture" + this.props.capture.id}</label><br/><br/>
                   </div>
                </div>
             </div>

--- a/gui/src/pages/components/environment_modal_comp.tsx
+++ b/gui/src/pages/components/environment_modal_comp.tsx
@@ -23,8 +23,8 @@ export class EnvModal extends React.Component<any, any>  {
         this.cancelModal = this.cancelModal.bind(this);
         this.changeProgress = this.changeProgress.bind(this);
         this.state = {envName: "", accessKey: "", secretKey: "", region: "", bucketList: [], envNameValid: 'invalid',
-                      dbName: "", pass: "", bucket: "", prefix: "", dbRefs: [], invalidDBPass: false, modalPage: '1',
-                      envNameDuplicate: false,
+                      dbName: "", pass: "", bucket: "", prefix: "MyCRT", dbRefs: [], invalidDBPass: false,
+                      modalPage: '1', envNameDuplicate: false,
                       disabled: true, buttonText: 'Continue', credentialsValid: 'valid', dbCredentialsValid: 'valid'};
         this.baseState = this.state;
     }

--- a/gui/src/pages/components/environment_modal_comp.tsx
+++ b/gui/src/pages/components/environment_modal_comp.tsx
@@ -23,7 +23,7 @@ export class EnvModal extends React.Component<any, any>  {
         this.cancelModal = this.cancelModal.bind(this);
         this.changeProgress = this.changeProgress.bind(this);
         this.state = {envName: "", accessKey: "", secretKey: "", region: "", bucketList: [], envNameValid: 'invalid',
-                      dbName: "", pass: "", bucket: "", dbRefs: [], invalidDBPass: false, modalPage: '1',
+                      dbName: "", pass: "", bucket: "", prefix: "", dbRefs: [], invalidDBPass: false, modalPage: '1',
                       envNameDuplicate: false,
                       disabled: true, buttonText: 'Continue', credentialsValid: 'valid', dbCredentialsValid: 'valid'};
         this.baseState = this.state;
@@ -95,6 +95,10 @@ export class EnvModal extends React.Component<any, any>  {
         host: dbRef.host, user: dbRef.user, pass: "", invalidDBPass: false});
     }
 
+    public handlePrefixChange(event: any) {
+      this.setState({ prefix: event.target.value });
+    }
+
     public handleS3Ref(event: any) {
         const bucket = event.currentTarget.value;
         if (bucket === "default") {
@@ -120,7 +124,7 @@ export class EnvModal extends React.Component<any, any>  {
          this.setState({envNameValid: 'invalid', disabled: true});
       }
       this.setState({[event.target.id]: event.target.value, envNameDuplicate: false});
-  }
+    }
 
     public async createEnvironment() {
         const envObj = await mycrt.createEnvironment(this.state as IEnvironmentFull);
@@ -284,6 +288,11 @@ export class EnvModal extends React.Component<any, any>  {
                                             <option value="default">Select S3 Bucket...</option>
                                             {buckets}
                                         </select>} <br/>
+                                        <label>Prefix Name (Optional):</label>
+                                        <input className="form-control input-lg"
+                                          placeholder="Enter S3 Prefix"
+                                          value={this.state.prefix} id="prefix"
+                                          onInput={this.handlePrefixChange.bind(this)}/>
                                     </div>
                                 </div>
                                 <div className="modal-footer">

--- a/gui/src/pages/components/replay_info_comp.tsx
+++ b/gui/src/pages/components/replay_info_comp.tsx
@@ -20,8 +20,8 @@ export class ReplayInfo extends React.Component<any, any>  {
       return time.toLocaleString();
    }
 
-   public deleteReplay(id: number) {
-      this.props.delete(id);
+   public deleteReplay(id: number, deleteLogs: boolean) {
+      this.props.delete(id, deleteLogs);
    }
 
    public compareReplay() {

--- a/gui/src/pages/components/replay_info_comp.tsx
+++ b/gui/src/pages/components/replay_info_comp.tsx
@@ -67,7 +67,7 @@ export class ReplayInfo extends React.Component<any, any>  {
                   <div className="col-xs-6" style={{padding: "20px 20px 0px"}}>
                      <h5>S3 File Storage:</h5>
                      <label><b>&nbsp;&nbsp;&nbsp;Bucket: </b>{this.props.bucket}</label><br/>
-                     <label><b>&nbsp;&nbsp;&nbsp;Folder: </b>{"replay" + this.props.replay.id}</label><br/><br/>
+                     <label><b>&nbsp;&nbsp;&nbsp;Prefix: </b>{this.props.prefix}</label><br/><br/>
                   </div>
                </div>
             </div>

--- a/gui/src/pages/components/replay_info_comp.tsx
+++ b/gui/src/pages/components/replay_info_comp.tsx
@@ -67,7 +67,8 @@ export class ReplayInfo extends React.Component<any, any>  {
                   <div className="col-xs-6" style={{padding: "20px 20px 0px"}}>
                      <h5>S3 File Storage:</h5>
                      <label><b>&nbsp;&nbsp;&nbsp;Bucket: </b>{this.props.bucket}</label><br/>
-                     <label><b>&nbsp;&nbsp;&nbsp;Prefix: </b>{this.props.prefix}</label><br/><br/>
+                     <label><b>&nbsp;&nbsp;&nbsp;Prefix: </b>{this.props.prefix + "/environment" +
+                        this.props.envId + "/replay" + this.props.replay.id}</label><br/><br/>
                   </div>
                </div>
             </div>

--- a/gui/src/pages/dashboard.tsx
+++ b/gui/src/pages/dashboard.tsx
@@ -172,6 +172,7 @@ class DashboardApp extends React.Component<any, any> {
                            <div className="col-xs-6" style={{padding: "20px 40px 0px"}}>
                               <h5>S3 File Storage:</h5>
                               <label><b>&nbsp;&nbsp;&nbsp;Bucket: </b>{this.state.env.bucket}</label>
+                              <label><b>&nbsp;&nbsp;&nbsp;Prefix: </b>{this.state.env.prefix}</label>
                            </div>
                         </div>
                      </div>

--- a/gui/src/pages/dashboard.tsx
+++ b/gui/src/pages/dashboard.tsx
@@ -172,7 +172,8 @@ class DashboardApp extends React.Component<any, any> {
                            <div className="col-xs-6" style={{padding: "20px 40px 0px"}}>
                               <h5>S3 File Storage:</h5>
                               <label><b>&nbsp;&nbsp;&nbsp;Bucket: </b>{this.state.env.bucket}</label>
-                              <label><b>&nbsp;&nbsp;&nbsp;Prefix: </b>{this.state.env.prefix}</label>
+                              <label><b>&nbsp;&nbsp;&nbsp;Prefix: </b>{this.state.env.prefix +
+                                 "/environment" + this.state.env.id}</label>
                            </div>
                         </div>
                      </div>

--- a/replay/src/main.ts
+++ b/replay/src/main.ts
@@ -61,7 +61,7 @@ async function runReplay(): Promise<void> {
                new S3({
                   region: capEnv.region,
                   accessKeyId: capEnv.accessKey,
-                  secretAccessKey: capEnv.secretKey}), capEnv.bucket);
+                  secretAccessKey: capEnv.secretKey}), capEnv.bucket, capEnv.prefix);
             const metrics = new CloudWatchMetricsBackend(
                new CloudWatch({ region: capEnv.region,
                                  accessKeyId: capEnv.accessKey,

--- a/replay/src/main.ts
+++ b/replay/src/main.ts
@@ -71,7 +71,7 @@ async function runReplay(): Promise<void> {
          };
 
          const buildMockReplay = (): Replay => {
-            const storage = new LocalBackend(getSandboxPath());
+            const storage = new LocalBackend(getSandboxPath(), capEnv.prefix);
             const metrics = new MockMetricsBackend(5);
             return new Replay(config, storage, metrics, db);
          };

--- a/replay/src/replay.ts
+++ b/replay/src/replay.ts
@@ -71,7 +71,8 @@ export class Replay extends Subprocess implements IReplayIpcNodeDelegate {
 
          this.capture = await captureDao.getCapture(this.config.captureId);
 
-         if (this.capture !== null) {
+         if (this.capture) {
+            logger.info(`Found a capture for the replay with environment ${this.capture.envId}`);
             this.envId = this.capture.envId;
          }
 
@@ -183,6 +184,7 @@ export class Replay extends Subprocess implements IReplayIpcNodeDelegate {
       this.workloadPath = schema.workload.getDoneKey({
          id: this.capture!.id,
          type: ChildProgramType.CAPTURE,
+         envId: this.capture!.envId,
       });
 
       const temp: IWorkload = await this.storage.readJson<IWorkload>(this.workloadPath);

--- a/replay/src/replay.ts
+++ b/replay/src/replay.ts
@@ -30,6 +30,7 @@ export class Replay extends Subprocess implements IReplayIpcNodeDelegate {
    private replayEndTime?: Moment;
    private workloadPath?: string;
    private workloadIndex: number = 0;
+   private envId?: number;
 
    constructor(public config: ReplayConfig, storage: StorageBackend, metrics: MetricsBackend, db: IDbReference) {
       super(storage, metrics);
@@ -55,6 +56,7 @@ export class Replay extends Subprocess implements IReplayIpcNodeDelegate {
          type: ChildProgramType.REPLAY,
          status: this.status,
          start: this.startTime || undefined,
+         envId: this.envId,
       };
    }
 
@@ -68,6 +70,10 @@ export class Replay extends Subprocess implements IReplayIpcNodeDelegate {
          this.ipcNode.start();
 
          this.capture = await captureDao.getCapture(this.config.captureId);
+
+         if (this.capture !== null) {
+            this.envId = this.capture.envId;
+         }
 
          this.targetDb = this.config.mock ? mycrtDbConfig : { database: this.dbRef.name,
                                                               host: this.dbRef.host,

--- a/scripts/db/mycrt.sql
+++ b/scripts/db/mycrt.sql
@@ -65,7 +65,8 @@ CREATE TABLE DBReference (
 
 CREATE TABLE S3Reference (
    id INT(11) AUTO_INCREMENT PRIMARY KEY,
-   bucket VARCHAR(32)
+   bucket VARCHAR(32),
+   prefix VARCHAR(32)
 );
 
 CREATE TABLE Capture (

--- a/service/src/common/capture-replay-metrics.ts
+++ b/service/src/common/capture-replay-metrics.ts
@@ -22,6 +22,7 @@ export const getMetrics = (childProgram: IChildProgram, environment: IEnvironmen
       Promise<IMetricsList | IMetricsList[]> => {
 
    logger.info(`Getting ${metricType} metrics for ${childProgram.type} ${childProgram.id}`);
+   childProgram.envId = environment.id;
 
    const validStatus = childProgram.status && [ChildProgramStatus.DONE, ChildProgramStatus.RUNNING,
    ChildProgramStatus.STOPPING].indexOf(childProgram.status) > -1;

--- a/service/src/common/capture-replay-metrics.ts
+++ b/service/src/common/capture-replay-metrics.ts
@@ -40,7 +40,7 @@ export const getMetrics = (childProgram: IChildProgram, environment: IEnvironmen
          accessKeyId: environment.accessKey,
          secretAccessKey: environment.secretKey,
       };
-      backend = new S3Backend(new S3(awsConfig), environment.bucket);
+      backend = new S3Backend(new S3(awsConfig), environment.bucket, environment.prefix);
    }
    const storage = new MetricsStorage(backend);
 

--- a/service/src/common/capture-replay-metrics.ts
+++ b/service/src/common/capture-replay-metrics.ts
@@ -33,7 +33,7 @@ export const getMetrics = (childProgram: IChildProgram, environment: IEnvironmen
    const mocking: boolean = settings.captures.mock && childProgram.type === ChildProgramType.CAPTURE
       || settings.replays.mock && childProgram.type === ChildProgramType.REPLAY;
    if (mocking) {
-      backend = new LocalBackend(getSandboxPath());
+      backend = new LocalBackend(getSandboxPath(), environment.prefix);
    } else {
       const awsConfig: S3.ClientConfiguration = {
          region: environment.region,

--- a/service/src/request-schema/common-schema.ts
+++ b/service/src/request-schema/common-schema.ts
@@ -26,6 +26,9 @@ export const value = {
    // https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
    bucket: joi.string().regex(/^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$/),
 
+   /** An S3 bucket prefix */
+   prefix: joi.string().regex(/^[a-zA-Z0-9 :_\-]{4,}$/),
+
    /** A database name */
    // https://dev.mysql.com/doc/refman/5.7/en/identifiers.html
    dbName: joi.string().regex(/^[0-9a-zA-Z\$_]+$/).max(64),

--- a/service/src/request-schema/common-schema.ts
+++ b/service/src/request-schema/common-schema.ts
@@ -29,7 +29,8 @@ export const value = {
    bucket: joi.string().regex(/^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$/),
 
    /** An S3 bucket prefix */
-   prefix: joi.string().regex(/^[a-zA-Z0-9 :_\-]{4,}$/),
+   // TODO: Figure out the right regex for this (just used a random one for now)
+   prefix: joi.string().allow(""),
 
    /** A database name */
    // https://dev.mysql.com/doc/refman/5.7/en/identifiers.html

--- a/service/src/request-schema/environment-schema.ts
+++ b/service/src/request-schema/environment-schema.ts
@@ -8,7 +8,7 @@ export const environmentBody: joi.ObjectSchema = joi.object().keys({
    secretKey: value.secretKey.required(),
    region: value.region.required(),
    bucket: value.bucket.required(),
-   prefix: value.prefix.required(),
+   prefix: value.prefix.optional(),
    dbName: value.dbName.required(),
    host: value.host.required(),
    user: value.user.required(),

--- a/service/src/request-schema/environment-schema.ts
+++ b/service/src/request-schema/environment-schema.ts
@@ -8,6 +8,7 @@ export const environmentBody: joi.ObjectSchema = joi.object().keys({
    secretKey: value.secretKey.required(),
    region: value.region.required(),
    bucket: value.bucket.required(),
+   prefix: value.prefix.required(),
    dbName: value.dbName.required(),
    host: value.host.required(),
    user: value.user.required(),

--- a/service/src/routes/capture.ts
+++ b/service/src/routes/capture.ts
@@ -222,8 +222,7 @@ export default class CaptureRouter extends SelfAwareRouter {
                      env.bucket, env.prefix,
                   );
 
-               const key = "capture" + id + "/";
-               await storage.deletePrefix(key);
+               await storage.deletePrefix("capture" + id);
             }
          }
 

--- a/service/src/routes/capture.ts
+++ b/service/src/routes/capture.ts
@@ -219,7 +219,7 @@ export default class CaptureRouter extends SelfAwareRouter {
                      new S3({region: env.region,
                         accessKeyId: env.accessKey,
                         secretAccessKey: env.secretKey}),
-                     env.bucket,
+                     env.bucket, env.prefix,
                   );
 
                const key = "capture" + id + "/";

--- a/service/src/routes/capture.ts
+++ b/service/src/routes/capture.ts
@@ -222,7 +222,8 @@ export default class CaptureRouter extends SelfAwareRouter {
                      env.bucket, env.prefix,
                   );
 
-               await storage.deletePrefix("capture" + id);
+               const capturePrefix = `environment${env.id}/capture${id}/`;
+               await storage.deletePrefix(capturePrefix);
             }
          }
 

--- a/service/src/routes/environment.ts
+++ b/service/src/routes/environment.ts
@@ -148,7 +148,7 @@ export default class EnvironmentRouter extends SelfAwareRouter {
                   env.bucket, env.prefix,
                );
 
-               await storage.deletePrefix(env.prefix);
+               await storage.deletePrefix("");
             }
          }
 

--- a/service/src/routes/environment.ts
+++ b/service/src/routes/environment.ts
@@ -148,7 +148,8 @@ export default class EnvironmentRouter extends SelfAwareRouter {
                   env.bucket, env.prefix,
                );
 
-               await storage.deletePrefix("");
+               const envPrefix = `environment${env.id}/`;
+               await storage.deletePrefix(envPrefix);
             }
          }
 

--- a/service/src/routes/environment.ts
+++ b/service/src/routes/environment.ts
@@ -5,6 +5,8 @@ import * as http from 'http-status-codes';
 import { Logging, ServerIpcNode } from '@lbt-mycrt/common';
 import * as data from '@lbt-mycrt/common/dist/data';
 
+import { S3Backend } from '@lbt-mycrt/common/dist/storage/s3-backend';
+
 import * as session from '../auth/session';
 import { environmentDao } from '../dao/mycrt-dao';
 import { HttpError } from '../http-error';
@@ -70,6 +72,7 @@ export default class EnvironmentRouter extends SelfAwareRouter {
          };
          let s3Reference: data.IS3Reference = {
             bucket: request.body.bucket,
+            prefix: request.body.prefix,
          };
          let dbReference: data.IDbReference = {
             name: request.body.dbName,
@@ -119,23 +122,23 @@ export default class EnvironmentRouter extends SelfAwareRouter {
          const id = request.params.id;
          const deleteLogs: boolean | undefined = request.query.deleteLogs;
 
-         const environment = await environmentDao.deleteEnvironment(id);
-         if (!environment) {
-            throw new HttpError(http.NOT_FOUND);
-         }
-
          if (deleteLogs === true) {
             const env = await environmentDao.getEnvironmentFull(id);
             if (env) {
-               // TODO: needs to be replaced by a S3StorageBackend object in the Capture Object
-               const s3 = new S3(
-                  {region: env.region, accessKeyId: env.accessKey, secretAccessKey: env.secretKey},
+               const storage = new S3Backend(
+                  new S3({region: env.region,
+                     accessKeyId: env.accessKey,
+                     secretAccessKey: env.secretKey}),
+                  env.bucket, env.prefix,
                );
 
-               // TODO: Remove environment bucket from s3 (should just be s3.deleteBucket call)
-               const s3Params = { Bucket: env.bucket };
-               logger.info("Deleting environment bucket not implemented.");
+               await storage.deletePrefix(env.prefix);
             }
+         }
+
+         const environment = await environmentDao.deleteEnvironment(id);
+         if (!environment) {
+            throw new HttpError(http.NOT_FOUND);
          }
 
          response.json(environment);

--- a/service/src/routes/replay.ts
+++ b/service/src/routes/replay.ts
@@ -165,8 +165,7 @@ export default class ReplayRouter extends SelfAwareRouter {
                      env.bucket, env.prefix,
                   );
 
-               const key = "replay" + id + "/";
-               await storage.deletePrefix(key);
+               await storage.deletePrefix("replay" + id);
             }
          }
 

--- a/service/src/routes/replay.ts
+++ b/service/src/routes/replay.ts
@@ -165,7 +165,8 @@ export default class ReplayRouter extends SelfAwareRouter {
                      env.bucket, env.prefix,
                   );
 
-               await storage.deletePrefix("replay" + id);
+               const replayPrefix = `environment${env.id}/replay${id}/`;
+               await storage.deletePrefix(replayPrefix);
             }
          }
 


### PR DESCRIPTION
- Added the ability for a user to specify a prefix that all of their capture/replay files would go to for a given environment. The default prefix is MyCRT (but users can change it). An example new S3 file storage path is my-test-bucket/MyCRT/environment1/capture1/metrics.json.

Additional things in this PR:
- Updated some tests to expect the new file storage paths
- bug fix [LIL-217]: Added ability to remove environment prefix in DELETE environment logic 
- bug fix [LIL-218]: Updated DELETE replay logic to remove replay folders from S3