### PR TITLE
Handle missing S3 resources

### DIFF
--- a/cli/src/mycrt-client/client.ts
+++ b/cli/src/mycrt-client/client.ts
@@ -29,7 +29,7 @@ export class MyCrtClient {
 
    /** Create a new Capture */
    public async startCapture(capture: IChildProgram): Promise<IChildProgram | null> {
-      return this.makeRequest<IChildProgram>(HttpMethod.POST, '/captures', null, capture);
+      return this.makeRequest<IChildProgram>(HttpMethod.POST, '/captures', {envId: capture.envId}, capture);
    }
 
    /** Stop a specific capture */
@@ -145,6 +145,21 @@ export class MyCrtClient {
    /** Validate credentials when creating an environment */
    public async validateCredentials(awsKeys: IAwsKeys): Promise< IDbReference[]| null> {
       return this.makeRequest<IDbReference[]>(HttpMethod.POST, `/validate/credentials`, null, awsKeys);
+   }
+
+   /** Validate the associated S3 Storage for an environment */
+   public async validateStorage(envId: number): Promise<any | null> {
+      return this.makeRequest<any>(HttpMethod.GET, `/validate/bucket/`, {envId});
+   }
+
+   /** Validate that the associated metrics file can be found in S3 */
+   public async validateMetricsFile(envId: number, type: string, id: number): Promise<any | null> {
+      return this.makeRequest<any>(HttpMethod.GET, `/validate/bucket/metrics`, {envId, id, type});
+   }
+
+   /** Validate that the associated workload file can be found in S3 */
+   public async validateWorkloadFile(envId: number, id: number): Promise<any | null> {
+      return this.makeRequest<any>(HttpMethod.GET, `/validate/bucket/workload`, {envId, id});
    }
 
    /** Validate buckets when creating an environment */

--- a/cli/src/mycrt-client/client.ts
+++ b/cli/src/mycrt-client/client.ts
@@ -29,7 +29,7 @@ export class MyCrtClient {
 
    /** Create a new Capture */
    public async startCapture(capture: IChildProgram): Promise<IChildProgram | null> {
-      return this.makeRequest<IChildProgram>(HttpMethod.POST, '/captures', {envId: capture.envId}, capture);
+      return this.makeRequest<IChildProgram>(HttpMethod.POST, '/captures', null, capture);
    }
 
    /** Stop a specific capture */

--- a/cli/src/mycrt-client/client.ts
+++ b/cli/src/mycrt-client/client.ts
@@ -154,7 +154,7 @@ export class MyCrtClient {
 
    /** Validate the associated S3 Storage for an environment */
    public async validateStorage(envId: number): Promise<any | null> {
-      return this.makeRequest<any>(HttpMethod.GET, `/validate/bucket/`, {envId});
+      return this.makeRequest<any>(HttpMethod.GET, `/validate/bucket`, {envId});
    }
 
    /** Validate that the associated metrics file can be found in S3 */

--- a/cli/src/mycrt-client/client.ts
+++ b/cli/src/mycrt-client/client.ts
@@ -123,6 +123,11 @@ export class MyCrtClient {
       return this.makeRequest<IEnvironment[]>(HttpMethod.GET, '/environments');
    }
 
+   /** Get all of the DB references for this environment */
+   public async getEnvironmentDbs(id: number): Promise<IDbReference[] | null> {
+      return this.makeRequest<IDbReference[]>(HttpMethod.GET, `/environments/${id}/dbs`);
+   }
+
    /** Edit an environment given the envId and the desired changes */
    public async editEnvironment(id: number, changes: IEnvironment): Promise<IEnvironment | null> {
       return this.makeRequest<IEnvironment>(HttpMethod.PUT, `/environments/${id}`, null, changes);

--- a/common/src/storage/backend.ts
+++ b/common/src/storage/backend.ts
@@ -3,6 +3,8 @@ export abstract class StorageBackend {
 
    public abstract async exists(key: string): Promise<boolean>;
 
+   public abstract async bucketExists(): Promise<boolean>;
+
    public abstract async allMatching(dirPrefix: string, pattern: RegExp): Promise<string[]>;
 
    public abstract async readJson<T>(key: string): Promise<T>;

--- a/common/src/storage/local-backend.ts
+++ b/common/src/storage/local-backend.ts
@@ -25,6 +25,10 @@ export class LocalBackend extends StorageBackend {
       return await fs.pathExists(file);
    }
 
+   public async bucketExists(): Promise<boolean> {
+      return await fs.pathExists(this.rootDir);
+   }
+
    public async allMatching(dirPrefix: string, pattern: RegExp): Promise<string[]> {
       dirPrefix = this.attachPrefix(dirPrefix);
       const fullDirPrefix = path.join(this.rootDir, dirPrefix);

--- a/common/src/storage/s3-backend.ts
+++ b/common/src/storage/s3-backend.ts
@@ -33,6 +33,25 @@ export class S3Backend extends StorageBackend {
       });
    }
 
+   public bucketExists(): Promise<boolean> {
+
+      const params: S3.HeadBucketRequest = {
+         Bucket: this.bucket,
+      };
+
+      return new Promise<boolean>((resolve, reject) => {
+         this.s3.headBucket(params, (err: AWSError, data: S3.HeadObjectOutput) => {
+            if (err && err.code === 'NotFound') {
+               resolve(false);
+            } else if (!err) {
+               resolve(true);
+            } else {
+               reject(err);
+            }
+         });
+      });
+   }
+
    public async allMatching(dirPrefix: string, pattern: RegExp): Promise<string[]> {
       dirPrefix = this.attachPrefix(dirPrefix);
       const keys = await this.listObjects(dirPrefix);

--- a/gui/src/pages/components/aws_keys_comp.tsx
+++ b/gui/src/pages/components/aws_keys_comp.tsx
@@ -95,7 +95,7 @@ export class AWSKeys extends React.Component<any, any>  {
                            onInput={this.secretKeyChange}/> <br/>
                         {<select className="form-control" id="regionDrop"
                            onChange={this.regionChange.bind(this)}>
-                           <option value='default'>Enter Region...</option>
+                           <option value='default'>Select Region...</option>
                            {this.props.regions}
                         </select>}
                      </div> :

--- a/gui/src/pages/components/capture_modal_comp.tsx
+++ b/gui/src/pages/components/capture_modal_comp.tsx
@@ -49,6 +49,14 @@ export class CaptureModal extends React.Component<any, any>  {
             Please use a different one.`});
          return;
       }
+
+      const bucketExists = await mycrt.validateStorage(this.props.envId);
+      if (!bucketExists) {
+         this.setState({errorMsg: `The bucket associated with this environment does not exist.
+            Please create a bucket in S3 named ${this.props.bucket}.`});
+         return;
+      }
+
       const capture = {name: this.state.captureName, envId: this.props.envId} as any;
       if (this.state.captureType === "specific") {
          capture.status = ChildProgramStatus.SCHEDULED;

--- a/gui/src/pages/components/replay_modal_comp.tsx
+++ b/gui/src/pages/components/replay_modal_comp.tsx
@@ -40,9 +40,7 @@ export class ReplayModal extends React.Component<any, any>  {
    }
 
    public async componentWillMount() {
-      const iamRef = {accessKey: this.state.env.accessKey, secretKey: this.state.env.secretKey,
-         region: this.state.env.region};
-      const dbRefs = await mycrt.validateCredentials(iamRef);
+      const dbRefs = await mycrt.getEnvironmentDbs(this.state.env.id);
       if (dbRefs) {
          const filterRefs = dbRefs.filter((db) => {
          return db.name !== this.state.env.dbName;

--- a/gui/src/pages/components/replay_modal_comp.tsx
+++ b/gui/src/pages/components/replay_modal_comp.tsx
@@ -90,6 +90,22 @@ export class ReplayModal extends React.Component<any, any>  {
          this.setState({errorMsg: 'This replay name already exists within this capture. Please use a different one.'});
          return;
       }
+
+      const bucketExists = await mycrt.validateStorage(this.state.env.id);
+      if (!bucketExists) {
+         this.setState({errorMsg: `The bucket associated with this environment does not exist.
+            Please create a bucket in S3 named ${this.state.env.bucket}.`});
+         return;
+      }
+
+      const workloadFileExists = await mycrt.validateWorkloadFile(this.state.env.id, this.state.captureId);
+      if (!workloadFileExists) {
+         const capture = this.props.captures[this.state.captureId];
+         this.setState({errorMsg: `Cannot run a replay on capture ${capture.name} because the `
+                                 + `workload.json file associated with this capture does not exist in S3.`});
+         return;
+      }
+
       const replay = {name: this.state.name, captureId: this.state.captureId, type: this.state.type,
          host: this.state.host, parameterGroup: this.state.parameterGroup, user: this.state.user,
          pass: this.state.pass, instance: this.state.instance, dbName: this.state.dbName} as IReplayFull;

--- a/gui/src/pages/dashboard.tsx
+++ b/gui/src/pages/dashboard.tsx
@@ -8,7 +8,9 @@ import './common';
 import '../../static/css/index.css';
 
 import { ICapture } from '../../../common/dist/main';
+import { showAlert } from '../actions';
 import { BrowserLogger as logger } from '../logging';
+import { store } from '../store';
 import { BasePage } from './components/base_page_comp';
 import { CaptureModal } from './components/capture_modal_comp';
 import { CapturePanel } from './components/capture_panel_comp';
@@ -88,6 +90,17 @@ class DashboardApp extends React.Component<any, any> {
          });
       }
       this.setCaptures();
+      const bucketExists = await mycrt.validateStorage(this.state.envId);
+      if (!bucketExists) {
+         logger.error("Bucket no longer exists.");
+         store.dispatch(showAlert({
+            show: true,
+            header: "Missing Storage Bucket",
+            message: "The bucket associated with this environment does not exist. "
+                     + "Please create a bucket in S3 named " + this.state.env.bucket
+                     + " before creating a capture or running a replay.",
+         }));
+      }
     }
 
     public async deleteEnv(id: number, deleteLogs: boolean) {
@@ -192,7 +205,8 @@ class DashboardApp extends React.Component<any, any> {
                            data-target="#captureModal" style={{marginBottom: "12px", marginLeft: "12px"}}>
                             <i className="fa fa-plus" aria-hidden="true"></i>
                         </a>
-                        <CaptureModal id="captureModal" envId={this.state.envId} update={this.componentWillMount}/>
+                        <CaptureModal id="captureModal" envId={this.state.envId} bucket={this.state.env.bucket}
+                        update={this.componentWillMount}/>
                      </div>
                      <br></br>
                      <h4 style={{padding: "10px", display: "inline-block"}}>Active</h4>

--- a/service/src/auth/middleware.ts
+++ b/service/src/auth/middleware.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Request, Response } from 'express';
+import * as http from 'http-status-codes';
+
+import { environmentDao, environmentInviteDao as inviteDao} from '../dao/mycrt-dao';
+import { HttpError } from '../http-error';
+
+export const makeSureUserIsEnvironmentMember = async (request: Request, response: Response,
+      next: NextFunction) => {
+
+   const envId = request.query.envId;
+   const environment = await environmentDao.getEnvironment(envId);
+   if (!environment) {
+      throw new HttpError(http.NOT_FOUND);
+   }
+
+   const membership = await inviteDao.getUserMembership(request.user!, environment);
+   if (!membership.isMember) {
+      throw new HttpError(http.NOT_FOUND);
+   }
+
+   next();
+
+};

--- a/service/src/auth/middleware.ts
+++ b/service/src/auth/middleware.ts
@@ -1,20 +1,28 @@
 import { NextFunction, Request, Response } from 'express';
 import * as http from 'http-status-codes';
 
+import { Logging } from '@lbt-mycrt/common';
+
 import { environmentDao, environmentInviteDao as inviteDao} from '../dao/mycrt-dao';
 import { HttpError } from '../http-error';
 
-export const makeSureUserIsEnvironmentMember = async (request: Request, response: Response,
-      next: NextFunction) => {
+const logger = Logging.defaultLogger(__dirname);
 
-   const envId = request.query.envId;
+export type EnvironmentIdGetter = (request: Request) => number;
+
+export const makeSureUserIsEnvironmentMember = (envIdGetter: EnvironmentIdGetter) =>
+      async (request: Request, response: Response, next: NextFunction) => {
+
+   const envId = envIdGetter(request);
    const environment = await environmentDao.getEnvironment(envId);
    if (!environment) {
+      logger.warn(`Environment ${request.query.envId} does not exist`);
       throw new HttpError(http.NOT_FOUND);
    }
 
    const membership = await inviteDao.getUserMembership(request.user!, environment);
-   if (!membership.isMember) {
+   if (!membership.isMember && environment.ownerId !== request.user!.id) {
+      logger.warn(`User ${request.user!.email} is not part of environment`);
       throw new HttpError(http.NOT_FOUND);
    }
 

--- a/service/src/common/rdsInstances.ts
+++ b/service/src/common/rdsInstances.ts
@@ -1,0 +1,33 @@
+import { RDS } from 'aws-sdk';
+import * as http from 'http-status-codes';
+
+import { IDbReference } from '@lbt-mycrt/common';
+import { HttpError } from '../http-error';
+
+const getDBInstancesFromAws = (rds: RDS, params: any): Promise<any> => {
+   return new Promise((resolve, reject) => {
+      rds.describeDBInstances(params, (err, data) => {
+         if (err) {
+            reject(err);
+         } else {
+            resolve(data);
+         }
+      });
+   });
+};
+
+export const getDbInstances = async (rds: RDS, params: any): Promise<IDbReference[]> => {
+   try {
+      const data = await getDBInstancesFromAws(rds, params);
+      return data.DBInstances.map((dbInstance: RDS.DBInstance): IDbReference => ({
+         instance: dbInstance.DBInstanceIdentifier,
+         name: dbInstance.DBName || dbInstance.DBInstanceIdentifier,
+         user: dbInstance.MasterUsername,
+         host: dbInstance.Endpoint ? dbInstance.Endpoint.Address : "",
+         parameterGroup: dbInstance.DBParameterGroups ?
+            dbInstance.DBParameterGroups[0].DBParameterGroupName : "",
+      }));
+   } catch (e) {
+      throw new HttpError(http.BAD_REQUEST, "Credentials are invalid");
+   }
+};

--- a/service/src/request-schema/validate-schema.ts
+++ b/service/src/request-schema/validate-schema.ts
@@ -23,3 +23,18 @@ export const databaseBody: joi.ObjectSchema = joi.object().keys({
 export const environmentNameBody: joi.ObjectSchema = joi.object().keys({
    name: value.nameString.required(),
 });
+
+export const bucketQuery: joi.ObjectSchema = joi.object().keys({
+   envId: value.id.required(),
+});
+
+export const bucketMetricsQuery: joi.ObjectSchema = joi.object().keys({
+   envId: value.id.required(),
+   id: value.id.required(),
+   type: joi.string().regex(/^(?:capture|replay)$/).required(),
+});
+
+export const bucketWorkloadQuery: joi.ObjectSchema = joi.object().keys({
+   envId: value.id.required(),
+   id: value.id.required(),
+});

--- a/service/src/routes/capture.ts
+++ b/service/src/routes/capture.ts
@@ -77,18 +77,6 @@ export default class CaptureRouter extends SelfAwareRouter {
             throw new HttpError(http.CONFLICT, `Capture ${capture.id}'s environment does not exist`);
          }
 
-         const storage = new S3Backend(
-            new S3({region: environment.region,
-               accessKeyId: environment.accessKey,
-               secretAccessKey: environment.secretKey}),
-               environment.bucket, environment.prefix,
-         );
-
-         const bucketExists = await storage.bucketExists();
-         if (!bucketExists) {
-            throw new HttpError(http.BAD_REQUEST, `S3 Bucket ${environment.bucket} does not exist`);
-         }
-
          const result = await getMetrics(capture, environment, type);
          response.json(result);
 
@@ -192,21 +180,9 @@ export default class CaptureRouter extends SelfAwareRouter {
                endTime = this.createEndDate(inputTime, duration);
             }
 
-            const env = await environmentDao.getEnvironmentFull(request.body.envId);
+            const env = await environmentDao.getEnvironment(request.body.envId);
             if (!env) {
                throw new HttpError(http.BAD_REQUEST, `Environment ${request.body.envId} does not exist`);
-            }
-
-            const storage = new S3Backend(
-               new S3({region: env.region,
-                  accessKeyId: env.accessKey,
-                  secretAccessKey: env.secretKey}),
-               env.bucket, env.prefix,
-            );
-
-            const bucketExists = await storage.bucketExists();
-            if (!bucketExists) {
-               throw new HttpError(http.BAD_REQUEST, `S3 Bucket ${env.bucket} does not exist`);
             }
 
             if (initialStatus === ChildProgramStatus.SCHEDULED && !request.body.scheduledStart) {

--- a/service/src/routes/replay.ts
+++ b/service/src/routes/replay.ts
@@ -86,18 +86,6 @@ export default class ReplayRouter extends SelfAwareRouter {
             throw new HttpError(http.CONFLICT, `Replay ${replay.id}'s environment does not exist`);
          }
 
-         const storage = new S3Backend(
-            new S3({region: environment.region,
-               accessKeyId: environment.accessKey,
-               secretAccessKey: environment.secretKey}),
-               environment.bucket, environment.prefix,
-         );
-
-         const bucketExists = await storage.bucketExists();
-         if (!bucketExists) {
-            throw new HttpError(http.BAD_REQUEST, `S3 Bucket ${environment.bucket} does not exist`);
-         }
-
          const result = await getMetrics(replay, environment, type);
          response.json(result);
 
@@ -114,25 +102,6 @@ export default class ReplayRouter extends SelfAwareRouter {
          const cap = await captureDao.getCapture(request.body.captureId);
          if (cap == null) {
                throw new HttpError(http.BAD_REQUEST, `Capture ${request.body.captureId} does not exist`);
-         }
-
-         if (cap.envId) {
-            const env = await environmentDao.getEnvironmentFull(cap.envId);
-            if (!env) {
-               throw new HttpError(http.BAD_REQUEST, `Environment ${request.body.envId} does not exist`);
-            }
-
-            const storage = new S3Backend(
-               new S3({region: env.region,
-                  accessKeyId: env.accessKey,
-                  secretAccessKey: env.secretKey}),
-               env.bucket, env.prefix,
-            );
-
-            const bucketExists = await storage.bucketExists();
-            if (!bucketExists) {
-               throw new HttpError(http.BAD_REQUEST, `S3 Bucket ${env.bucket} does not exist`);
-            }
          }
 
          if (initialStatus === ChildProgramStatus.SCHEDULED && !request.body.scheduledStart) {

--- a/service/src/routes/replay.ts
+++ b/service/src/routes/replay.ts
@@ -86,6 +86,18 @@ export default class ReplayRouter extends SelfAwareRouter {
             throw new HttpError(http.CONFLICT, `Replay ${replay.id}'s environment does not exist`);
          }
 
+         const storage = new S3Backend(
+            new S3({region: environment.region,
+               accessKeyId: environment.accessKey,
+               secretAccessKey: environment.secretKey}),
+               environment.bucket, environment.prefix,
+         );
+
+         const bucketExists = await storage.bucketExists();
+         if (!bucketExists) {
+            throw new HttpError(http.BAD_REQUEST, `S3 Bucket ${environment.bucket} does not exist`);
+         }
+
          const result = await getMetrics(replay, environment, type);
          response.json(result);
 
@@ -102,6 +114,25 @@ export default class ReplayRouter extends SelfAwareRouter {
          const cap = await captureDao.getCapture(request.body.captureId);
          if (cap == null) {
                throw new HttpError(http.BAD_REQUEST, `Capture ${request.body.captureId} does not exist`);
+         }
+
+         if (cap.envId) {
+            const env = await environmentDao.getEnvironmentFull(cap.envId);
+            if (!env) {
+               throw new HttpError(http.BAD_REQUEST, `Environment ${request.body.envId} does not exist`);
+            }
+
+            const storage = new S3Backend(
+               new S3({region: env.region,
+                  accessKeyId: env.accessKey,
+                  secretAccessKey: env.secretKey}),
+               env.bucket, env.prefix,
+            );
+
+            const bucketExists = await storage.bucketExists();
+            if (!bucketExists) {
+               throw new HttpError(http.BAD_REQUEST, `S3 Bucket ${env.bucket} does not exist`);
+            }
          }
 
          if (initialStatus === ChildProgramStatus.SCHEDULED && !request.body.scheduledStart) {

--- a/service/src/routes/replay.ts
+++ b/service/src/routes/replay.ts
@@ -117,7 +117,7 @@ export default class ReplayRouter extends SelfAwareRouter {
 
          const isUserMember = await inviteDao.getUserMembership(request.user!, environment!);
          if (isUserMember.isMember) {
-            const result = await getMetrics(capture, environment!, type);
+            const result = await getMetrics(replay, environment!, type);
             response.json(result);
          } else {
             throw new HttpError(http.UNAUTHORIZED);

--- a/service/src/routes/validate.ts
+++ b/service/src/routes/validate.ts
@@ -94,74 +94,80 @@ export default class ValidateRouter extends SelfAwareRouter {
       }));
 
       this.router.get('/bucket',
+         check.validQuery(schema.bucketQuery),
          this.handleHttpErrors(async (request, response) => {
-         const envId = request.query.envId;
-         const environment = await environmentDao.getEnvironmentFull(envId);
-         if (!environment) {
-            throw new HttpError(http.BAD_REQUEST, `Environment ${envId} does not exist`);
-         }
-         const storage = new S3Backend(
-            new S3({region: environment.region,
-               accessKeyId: environment.accessKey,
-               secretAccessKey: environment.secretKey}),
-               environment.bucket, environment.prefix,
-         );
+            const envId = request.query.envId;
+            const environment = await environmentDao.getEnvironmentFull(envId);
+            if (!environment) {
+               throw new HttpError(http.BAD_REQUEST, `Environment ${envId} does not exist`);
+            }
+            const storage = new S3Backend(
+               new S3({region: environment.region,
+                  accessKeyId: environment.accessKey,
+                  secretAccessKey: environment.secretKey}),
+                  environment.bucket, environment.prefix,
+            );
 
-         const bucketExists = await storage.bucketExists();
-         if (!bucketExists) {
-            throw new HttpError(http.BAD_REQUEST, `S3 Bucket ${environment.bucket} does not exist`);
-         }
-         response.json(environment.bucket);
-      }));
+            const bucketExists = await storage.bucketExists();
+            if (!bucketExists) {
+               throw new HttpError(http.BAD_REQUEST, `S3 Bucket ${environment.bucket} does not exist`);
+            }
+            response.json(environment.bucket);
+         },
+      ));
 
       this.router.get('/bucket/metrics',
+         check.validQuery(schema.bucketMetricsQuery),
          this.handleHttpErrors(async (request, response) => {
-         const envId = request.query.envId;
-         const id = request.query.id;
-         const type = request.query.type;
+            const envId = request.query.envId;
+            const id = request.query.id;
+            const type = request.query.type;
 
-         const environment = await environmentDao.getEnvironmentFull(envId);
-         if (!environment) {
-            throw new HttpError(http.BAD_REQUEST, `Environment ${envId} does not exist`);
-         }
-         const storage = new S3Backend(
-            new S3({region: environment.region,
-               accessKeyId: environment.accessKey,
-               secretAccessKey: environment.secretKey}),
-               environment.bucket, environment.prefix,
-         );
+            const environment = await environmentDao.getEnvironmentFull(envId);
+            if (!environment) {
+               throw new HttpError(http.BAD_REQUEST, `Environment ${envId} does not exist`);
+            }
+            const storage = new S3Backend(
+               new S3({region: environment.region,
+                  accessKeyId: environment.accessKey,
+                  secretAccessKey: environment.secretKey}),
+                  environment.bucket, environment.prefix,
+            );
 
-         const key = `environment${envId}/${type}${id}/metrics.json`;
-         const metricsExist = await storage.exists(key);
-         if (!metricsExist) {
-            throw new HttpError(http.BAD_REQUEST, `Associated metrics file does not exist`);
-         }
-         response.json(environment.bucket);
-      }));
+            const key = `environment${envId}/${type}${id}/metrics.json`;
+            const metricsExist = await storage.exists(key);
+            if (!metricsExist) {
+               throw new HttpError(http.BAD_REQUEST, `Associated metrics file does not exist`);
+            }
+            response.json(environment.bucket);
+         },
+      ));
 
       this.router.get('/bucket/workload',
+         check.validQuery(schema.bucketWorkloadQuery),
          this.handleHttpErrors(async (request, response) => {
-         const envId = request.query.envId;
-         const id = request.query.id;
+            const envId = request.query.envId;
+            const id = request.query.id;
 
-         const environment = await environmentDao.getEnvironmentFull(envId);
-         if (!environment) {
-            throw new HttpError(http.BAD_REQUEST, `Environment ${envId} does not exist`);
-         }
-         const storage = new S3Backend(
-            new S3({region: environment.region,
-               accessKeyId: environment.accessKey,
-               secretAccessKey: environment.secretKey}),
-               environment.bucket, environment.prefix,
-         );
+            const environment = await environmentDao.getEnvironmentFull(envId);
+            if (!environment) {
+               throw new HttpError(http.BAD_REQUEST, `Environment ${envId} does not exist`);
+            }
+            const storage = new S3Backend(
+               new S3({region: environment.region,
+                  accessKeyId: environment.accessKey,
+                  secretAccessKey: environment.secretKey}),
+                  environment.bucket, environment.prefix,
+            );
 
-         const key = `environment${envId}/capture${id}/workload.json`;
-         const workloadExists = await storage.exists(key);
-         if (!workloadExists) {
-            throw new HttpError(http.BAD_REQUEST, `Associated workload.json file does not exist`);
-         }
-         response.json(environment.bucket);
-      }));
+            const key = `environment${envId}/capture${id}/workload.json`;
+            const workloadExists = await storage.exists(key);
+            if (!workloadExists) {
+               throw new HttpError(http.BAD_REQUEST, `Associated workload.json file does not exist`);
+            }
+            response.json(environment.bucket);
+         },
+      ));
 
       this.router.post('/bucket', check.validBody(schema.credentialsBody),
          this.handleHttpErrors(async (request, response) => {

--- a/service/src/routes/validate.ts
+++ b/service/src/routes/validate.ts
@@ -4,8 +4,12 @@ import * as mysql from 'mysql';
 import http = require('http-status-codes');
 
 import { Logging, ServerIpcNode } from '@lbt-mycrt/common/dist/main';
+import { MetricsStorage } from '@lbt-mycrt/common/dist/metrics/metrics-storage';
+import { StorageBackend } from '@lbt-mycrt/common/dist/storage/backend';
+import { S3Backend } from '@lbt-mycrt/common/dist/storage/s3-backend';
 
 import * as session from '../auth/session';
+import { environmentDao } from '../dao/mycrt-dao';
 import { HttpError } from '../http-error';
 import * as check from '../middleware/request-validation';
 import * as schema from '../request-schema/validate-schema';
@@ -70,6 +74,76 @@ export default class ValidateRouter extends SelfAwareRouter {
          } catch (e) {
             throw new HttpError(http.BAD_REQUEST, "Can't connect to the database");
          }
+      }));
+
+      this.router.get('/bucket/',
+         this.handleHttpErrors(async (request, response) => {
+         const envId = request.query.envId;
+         const environment = await environmentDao.getEnvironmentFull(envId);
+         if (!environment) {
+            throw new HttpError(http.BAD_REQUEST, `Environment ${envId} does not exist`);
+         }
+         const storage = new S3Backend(
+            new S3({region: environment.region,
+               accessKeyId: environment.accessKey,
+               secretAccessKey: environment.secretKey}),
+               environment.bucket, environment.prefix,
+         );
+
+         const bucketExists = await storage.bucketExists();
+         if (!bucketExists) {
+            throw new HttpError(http.BAD_REQUEST, `S3 Bucket ${environment.bucket} does not exist`);
+         }
+         response.json(environment.bucket);
+      }));
+
+      this.router.get('/bucket/metrics/',
+         this.handleHttpErrors(async (request, response) => {
+         const envId = request.query.envId;
+         const id = request.query.id;
+         const type = request.query.type;
+
+         const environment = await environmentDao.getEnvironmentFull(envId);
+         if (!environment) {
+            throw new HttpError(http.BAD_REQUEST, `Environment ${envId} does not exist`);
+         }
+         const storage = new S3Backend(
+            new S3({region: environment.region,
+               accessKeyId: environment.accessKey,
+               secretAccessKey: environment.secretKey}),
+               environment.bucket, environment.prefix,
+         );
+
+         const key = `environment${envId}/${type}${id}/metrics.json`;
+         const metricsExist = await storage.exists(key);
+         if (!metricsExist) {
+            throw new HttpError(http.BAD_REQUEST, `Associated metrics file does not exist`);
+         }
+         response.json(environment.bucket);
+      }));
+
+      this.router.get('/bucket/workload/',
+         this.handleHttpErrors(async (request, response) => {
+         const envId = request.query.envId;
+         const id = request.query.id;
+
+         const environment = await environmentDao.getEnvironmentFull(envId);
+         if (!environment) {
+            throw new HttpError(http.BAD_REQUEST, `Environment ${envId} does not exist`);
+         }
+         const storage = new S3Backend(
+            new S3({region: environment.region,
+               accessKeyId: environment.accessKey,
+               secretAccessKey: environment.secretKey}),
+               environment.bucket, environment.prefix,
+         );
+
+         const key = `environment${envId}/capture${id}/workload.json`;
+         const workloadExists = await storage.exists(key);
+         if (!workloadExists) {
+            throw new HttpError(http.BAD_REQUEST, `Associated workload.json file does not exist`);
+         }
+         response.json(environment.bucket);
       }));
 
       this.router.post('/bucket', check.validBody(schema.credentialsBody),

--- a/service/src/routes/validate.ts
+++ b/service/src/routes/validate.ts
@@ -93,7 +93,7 @@ export default class ValidateRouter extends SelfAwareRouter {
          }
       }));
 
-      this.router.get('/bucket/',
+      this.router.get('/bucket',
          this.handleHttpErrors(async (request, response) => {
          const envId = request.query.envId;
          const environment = await environmentDao.getEnvironmentFull(envId);
@@ -114,7 +114,7 @@ export default class ValidateRouter extends SelfAwareRouter {
          response.json(environment.bucket);
       }));
 
-      this.router.get('/bucket/metrics/',
+      this.router.get('/bucket/metrics',
          this.handleHttpErrors(async (request, response) => {
          const envId = request.query.envId;
          const id = request.query.id;
@@ -139,7 +139,7 @@ export default class ValidateRouter extends SelfAwareRouter {
          response.json(environment.bucket);
       }));
 
-      this.router.get('/bucket/workload/',
+      this.router.get('/bucket/workload',
          this.handleHttpErrors(async (request, response) => {
          const envId = request.query.envId;
          const id = request.query.id;

--- a/service/src/routes/validate.ts
+++ b/service/src/routes/validate.ts
@@ -8,6 +8,7 @@ import { MetricsStorage } from '@lbt-mycrt/common/dist/metrics/metrics-storage';
 import { StorageBackend } from '@lbt-mycrt/common/dist/storage/backend';
 import { S3Backend } from '@lbt-mycrt/common/dist/storage/s3-backend';
 
+import { makeSureUserIsEnvironmentMember } from '../auth/middleware';
 import * as session from '../auth/session';
 import { environmentDao } from '../dao/mycrt-dao';
 import { HttpError } from '../http-error';
@@ -95,6 +96,7 @@ export default class ValidateRouter extends SelfAwareRouter {
 
       this.router.get('/bucket',
          check.validQuery(schema.bucketQuery),
+         this.handleHttpErrors(makeSureUserIsEnvironmentMember),
          this.handleHttpErrors(async (request, response) => {
             const envId = request.query.envId;
             const environment = await environmentDao.getEnvironmentFull(envId);
@@ -118,6 +120,7 @@ export default class ValidateRouter extends SelfAwareRouter {
 
       this.router.get('/bucket/metrics',
          check.validQuery(schema.bucketMetricsQuery),
+         this.handleHttpErrors(makeSureUserIsEnvironmentMember),
          this.handleHttpErrors(async (request, response) => {
             const envId = request.query.envId;
             const id = request.query.id;
@@ -145,6 +148,7 @@ export default class ValidateRouter extends SelfAwareRouter {
 
       this.router.get('/bucket/workload',
          check.validQuery(schema.bucketWorkloadQuery),
+         this.handleHttpErrors(makeSureUserIsEnvironmentMember),
          this.handleHttpErrors(async (request, response) => {
             const envId = request.query.envId;
             const id = request.query.id;


### PR DESCRIPTION
Change will now show errors to the user if their S3 resources cannot be reached.

- On environment homepage, show popup if bucket does not exist
- When creating a capture, display validation error if bucket does not exist
- When creating a replay, display validation error if bucket does not exist OR if selected capture's workload.json file does not exist in S3
- When viewing capture and replay metrics, display popup error if bucket does not exist OR if selected capture/replay's metrics.json file does not exist in S3
