### PR TITLE
restore OptionsDefinition description field

### DIFF
--- a/capture/src/args.ts
+++ b/capture/src/args.ts
@@ -1,5 +1,4 @@
 import * as readCmdArgs from 'command-line-args';
-import { OptionDefinition } from 'command-line-args';
 
 import { Config } from '@lbt-mycrt/common/dist/capture-replay/args';
 import { IEnvironmentFull } from '@lbt-mycrt/common/dist/data';
@@ -9,6 +8,10 @@ import { IEnvironmentFull } from '@lbt-mycrt/common/dist/data';
 //
 // notation rules documented here
 // https://github.com/75lb/command-line-args/wiki/Notation-rules
+
+export interface OptionDefinition extends readCmdArgs.OptionDefinition {
+   description?: string;
+}
 
 export const optionId: OptionDefinition = {
    name: 'id',

--- a/replay/src/args.ts
+++ b/replay/src/args.ts
@@ -1,5 +1,4 @@
 import * as readCmdArgs from 'command-line-args';
-import { OptionDefinition } from 'command-line-args';
 
 import { Config } from '@lbt-mycrt/common/dist/capture-replay/args';
 
@@ -8,6 +7,10 @@ import { Config } from '@lbt-mycrt/common/dist/capture-replay/args';
 //
 // notation rules documented here
 // https://github.com/75lb/command-line-args/wiki/Notation-rules
+
+export interface OptionDefinition extends readCmdArgs.OptionDefinition {
+   description?: string;
+}
 
 export const optionId: OptionDefinition = {
    name: 'id',


### PR DESCRIPTION
the description field of OptionDefinition was removed.

https://github.com/DefinitelyTyped/DefinitelyTyped/commit/89c307ca876427f1fb0659afca592bf086165a49#diff-ab88ff6e066f538deddd1692e14df27aL30

this replaces it manually